### PR TITLE
Validate that Tnt import file is specified

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -11,7 +11,7 @@ class Import < ActiveRecord::Base
   belongs_to :account_list
   # attr_accessible :file, :importing, :source, :file_cache, :override, :tags
   validates :source, inclusion: { in: %w(facebook twitter linkedin tnt google) }
-  # validates_with TntImportValidator, if: lambda {|import| 'tnt' == import.source }
+  validates_with TntImportValidator, if: ->(import) { 'tnt' == import.source }
   validates_with FacebookImportValidator, if: -> (import) { 'facebook' == import.source }
 
   serialize :groups, Array

--- a/app/validators/tnt_import_validator.rb
+++ b/app/validators/tnt_import_validator.rb
@@ -1,18 +1,9 @@
 class TntImportValidator < ActiveModel::Validator
   include ActionView::Helpers::UrlHelper
   def validate(import)
-    if import.file.file
-      tnt_import = TntImport.new(import)
-
-      xml = tnt_import.xml
-
-      # Make sure required columns are present
-      unless xml
-        import.errors[:base] << _('The file you uploaded is not a valid Tnt export. %{link}') %
-          { link: link_to(_('Please watch this video to see how to properly export from TntMPD.'), 'http://screencast.com/t/CU4y51KbRMkr', target: '_blank') }
-      end
-    else
-      import.errors[:base] << _('Please choose a file that ends with .xml')
+    # ImportUpload makes sure the file ends in .xml, we just need to to check that it's present here
+    unless import.file.present?
+      import.errors[:base] << _('You must specify a TntMPD .xml export file to upload to MPDX (see video linked below for more info).')
     end
   end
 end


### PR DESCRIPTION
We got some errors for `import.file` being nil and that seems to be cause by someone clicking "Import" from tnt when no file is specified. The ImportUploader validated that the extension was .xml but if no file was specified, no validation error was raised. This fixes that to show a validation error when no file specified.