### PR TITLE
have travis use .ruby-version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 cache: bundler
 language: ruby
-rvm:
-- 2.0.0
 services:
 - memcache
 - redis-server


### PR DESCRIPTION
Based on: http://docs.travis-ci.com/user/languages/ruby/#Using-.ruby-version