### PR TITLE
Merge people within contact by stripped downcase name

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -347,8 +347,8 @@ class Contact < ActiveRecord::Base
       next if merged_people.include?(person)
 
       other_people = people.select { |p|
-        p.first_name.strip.downcase == person.first_name.strip.downcase &&
-        p.last_name.strip.downcase == person.last_name.strip.downcase &&
+        p.first_name.to_s.strip.downcase == person.first_name.to_s.strip.downcase &&
+        p.last_name.to_s.strip.downcase == person.last_name.to_s.strip.downcase &&
         p.id != person.id
       }
       next unless other_people

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -347,8 +347,8 @@ class Contact < ActiveRecord::Base
       next if merged_people.include?(person)
 
       other_people = people.select { |p|
-        p.first_name == person.first_name &&
-        p.last_name == person.last_name &&
+        p.first_name.strip.downcase == person.first_name.strip.downcase &&
+        p.last_name.strip.downcase == person.last_name.strip.downcase &&
         p.id != person.id
       }
       next unless other_people

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -438,7 +438,7 @@ describe Contact do
         { first_name: 'John', last_name: 'Doe' } => { first_name: 'John', last_name: 'Doe' },
         { first_name: 'John ', last_name: 'Doe ' } => { first_name: 'John', last_name: 'Doe' },
         { first_name: 'john', last_name: 'doe' } => { first_name: 'JOHN', last_name: 'Doe' },
-        { first_name: 'joHn ', last_name: 'dOe' } => { first_name: ' JOHN', last_name: ' Doe' },
+        { first_name: 'joHn ', last_name: 'dOe' } => { first_name: ' JOHN', last_name: ' Doe' }
       }
       matches.each do |person_attrs1, person_attrs2|
         Person.destroy_all
@@ -460,6 +460,14 @@ describe Contact do
           contact.merge_people
         }.to_not change(Person, :count).from(2)
       end
+    end
+
+    it 'does not error but merges if last name is nil (first name cannot be blank)' do
+      contact.people << create(:person, last_name: nil)
+      contact.people << create(:person, last_name: nil)
+      expect {
+        contact.merge_people
+      }.to change(Person, :count).from(2).to(1)
     end
   end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -316,6 +316,11 @@ describe Contact do
       contact.merge(loser_contact)
       expect(contact.last_donation_date).to eq(Date.parse('2010-01-01'))
     end
+
+    it 'calls merge_people for the winner' do
+      expect(contact).to receive(:merge_people)
+      contact.merge(loser_contact)
+    end
   end
 
   context '#destroy' do
@@ -424,6 +429,37 @@ describe Contact do
       primary.update_attributes(last_name: '')
       contact.reload
       expect(contact.envelope_greeting).to eq('Fredrick & Loraine Doe')
+    end
+  end
+
+  context '#merge_people' do
+    it 'merges people with the same trimmed first and last name case insensitive' do
+      matches = {
+        { first_name: 'John', last_name: 'Doe' } => { first_name: 'John', last_name: 'Doe' },
+        { first_name: 'John ', last_name: 'Doe ' } => { first_name: 'John', last_name: 'Doe' },
+        { first_name: 'john', last_name: 'doe' } => { first_name: 'JOHN', last_name: 'Doe' },
+        { first_name: 'joHn ', last_name: 'dOe' } => { first_name: ' JOHN', last_name: ' Doe' },
+      }
+      matches.each do |person_attrs1, person_attrs2|
+        Person.destroy_all
+        contact.people << create(:person, person_attrs1)
+        contact.people << create(:person, person_attrs2)
+        expect {
+          contact.merge_people
+        }.to change(Person, :count).from(2).to(1)
+      end
+
+      non_matches = {
+        { first_name: 'Jane', last_name: 'Doe' } => { first_name: 'John', last_name: 'Doe' }
+      }
+      non_matches.each do |person_attrs1, person_attrs2|
+        Person.destroy_all
+        contact.people << create(:person, person_attrs1)
+        contact.people << create(:person, person_attrs2)
+        expect {
+          contact.merge_people
+        }.to_not change(Person, :count).from(2)
+      end
     end
   end
 end


### PR DESCRIPTION
Spencer found that people with the same names weren't getting auto merged when you merged contacts and from his example it was the name not getting stripped of whitespace. I added a check for case insensitive match as well.