### PR TITLE
Merge organization addresses rake task

### DIFF
--- a/lib/tasks/mpdx.rake
+++ b/lib/tasks/mpdx.rake
@@ -82,7 +82,7 @@ namespace :mpdx do
 
     account_lists = AccountList.joins(:users)
                       .joins('INNER JOIN person_organization_accounts ON person_organization_accounts.id = people.id')
-                      .where(organization_id: org.id)
+                      .where(person_organization_accounts: { organization_id: org.id })
     account_lists.each do |account_list|
       account_list.contacts.each { |c| merge_addresses(c) }
     end

--- a/lib/tasks/mpdx.rake
+++ b/lib/tasks/mpdx.rake
@@ -82,7 +82,7 @@ namespace :mpdx do
 
     account_lists = AccountList.joins(:users)
                       .joins('INNER JOIN person_organization_accounts ON person_organization_accounts.id = people.id')
-                      .where( {organization_id: org.id})
+                      .where(organization_id: org.id)
     account_lists.each do |account_list|
       account_list.contacts.each { |c| merge_addresses(c) }
     end

--- a/lib/tasks/mpdx.rake
+++ b/lib/tasks/mpdx.rake
@@ -54,6 +54,11 @@ namespace :mpdx do
     addresses = addressable.addresses.order('addresses.created_at')
     return unless addresses.length > 1
 
+    addresses.each do |address|
+      address.find_or_create_master_address
+      address.save
+    end
+
     addresses.reload
     addresses.each do |address|
       other_address = addresses.find { |a| a.equal_to?(address) && a.id != address.id }
@@ -81,7 +86,7 @@ namespace :mpdx do
     org.donor_accounts.each { |d| merge_addresses(d) }
 
     account_lists = AccountList.joins(:users)
-                      .joins('INNER JOIN person_organization_accounts ON person_organization_accounts.id = people.id')
+                      .joins('INNER JOIN person_organization_accounts ON person_organization_accounts.person_id = people.id')
                       .where(person_organization_accounts: { organization_id: org.id })
     account_lists.each do |account_list|
       account_list.contacts.each { |c| merge_addresses(c) }


### PR DESCRIPTION
I've been in touch with a DiscipleMakers staff who had a bunch of duplicate addresses in his account. I believe the origin is that their DataServer donor import had ignored the date_from parameter (which is actually allowed according to the [data server spec](http://www.tntware.com/tntmpd/faqs/en/how-can-i-make-my-organization-39-s-online-donation-system-compatible-with-tntmpd.aspx)), and a previous iteration of MPDX had pulled in duplicate addresses. Now the duplicate addresses are in their contacts as well as donor accounts. This rake task would merge those.

Should I write specs for the task or just test it out a bit with local data first?