### PR TITLE
Code to run org addresses merge in sidekiq

### DIFF
--- a/app/models/donor_account.rb
+++ b/app/models/donor_account.rb
@@ -1,6 +1,8 @@
 require_dependency 'address_methods'
 class DonorAccount < ActiveRecord::Base
   include AddressMethods
+  include Async # To allow batch processing of address merges
+  include Sidekiq::Worker
 
   has_many :master_person_donor_accounts, dependent: :destroy
   has_many :master_people, through: :master_person_donor_accounts

--- a/lib/tasks/mpdx.rake
+++ b/lib/tasks/mpdx.rake
@@ -50,12 +50,9 @@ namespace :mpdx do
     merge_donor_accounts
   end
 
-
   task address_cleanup: :environment do
     us_address = "addresses.id is not null AND (addresses.country is null or addresses.country = 'United States' or addresses.country = '' or addresses.country = 'United States of America')"
-    Contact.joins(:addresses).where(us_address).find_each do |c|
-      c.merge_addresses
-    end
+    Contact.joins(:addresses).where(us_address).find_each(&:merge_addresses)
   end
 
   # We had an organization, DiscipleMakers with a lot of duplicate addresses in its contacts and donor

--- a/lib/tasks/mpdx.rake
+++ b/lib/tasks/mpdx.rake
@@ -50,46 +50,29 @@ namespace :mpdx do
     merge_donor_accounts
   end
 
-  def merge_addresses(addressable)
-    addresses = addressable.addresses.order('addresses.created_at')
-    return unless addresses.length > 1
-
-    addresses.each do |address|
-      address.find_or_create_master_address
-      address.save
-    end
-
-    addresses.reload
-    addresses.each do |address|
-      other_address = addresses.find { |a| a.equal_to?(address) && a.id != address.id }
-      next unless other_address
-      address.merge(other_address)
-      merge_addresses(addressable)
-      return
-    end
-  end
 
   task address_cleanup: :environment do
     us_address = "addresses.id is not null AND (addresses.country is null or addresses.country = 'United States' or addresses.country = '' or addresses.country = 'United States of America')"
     Contact.joins(:addresses).where(us_address).find_each do |c|
-      merge_addresses(c)
+      c.merge_addresses
     end
   end
 
   # We had an organization, DiscipleMakers with a lot of duplicate addresses in its contacts and donor
   # accounts due to a difference in how their data server donor import worked and a previous iteration of
   # MPDX accepting duplicate addresses there. This will merge dup addresses in their donor accounts and
-  # contacts.
+  # contacts. The merging takes a while given the large number of duplicate addressees, so it made
+  # sense to run it as a background job.
   task :address_cleanup_organization, [:org_name] => :environment do |_task, args|
     org = Organization.find_by_name(args[:org_name])
     next unless org
-    org.donor_accounts.each { |d| merge_addresses(d) }
+    org.donor_accounts.each { |d| d.async(:merge_addresses) }
 
     account_lists = AccountList.joins(:users)
                       .joins('INNER JOIN person_organization_accounts ON person_organization_accounts.person_id = people.id')
                       .where(person_organization_accounts: { organization_id: org.id })
     account_lists.each do |account_list|
-      account_list.contacts.each { |c| merge_addresses(c) }
+      account_list.contacts.each { |c| c.async(:merge_addresses) }
     end
   end
 

--- a/spec/concerns/address_methods_spec.rb
+++ b/spec/concerns/address_methods_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe AddressMethods do
+  let(:contact) { create(:contact) }
+  let(:donor_account) { create(:donor_account) }
+
+  def expect_merge_addresses_works(addressable)
+    address1 = create(:address, street: '1 Way', master_address_id: 1)
+    address2 = create(:address, street: '1 Way', master_address_id: 1)
+    address3 = create(:address, street: '2 Way', master_address_id: 2)
+    addressable.addresses << address1
+    addressable.addresses << address2
+    addressable.addresses << address3
+
+    expect {
+      addressable.merge_addresses
+
+    }.to change(Address, :count).from(3).to(2)
+
+    expect(Address.find_by_id(address1.id)).to be_nil
+    expect(Address.find_by_id(address2.id)).to eq(address2)
+    expect(Address.find_by_id(address3.id)).to eq(address3)
+  end
+
+  describe '#merge_addresses' do
+    it 'works for contact' do
+      expect_merge_addresses_works(contact)
+    end
+
+    it 'works for donor_account' do
+      expect_merge_addresses_works(donor_account)
+    end
+  end
+end

--- a/spec/models/email_address_spec.rb
+++ b/spec/models/email_address_spec.rb
@@ -54,6 +54,5 @@ describe EmailAddress do
       person.email_addresses.first.email.should == email
       person.email_addresses.length.should == 1
     end
-
   end
 end


### PR DESCRIPTION
I ran the rake task to merge the DiscipleMakers addresses, and after running for a while eventually crashed the rails console instance (not sure why, but maybe hit some limit it has). Running the addresses merge function on single donor accounts or contacts would complete correctly but took a long time for large numbers (> 1000) of addresses per contact. I redesigned the merge addresses function to be iterative and just require a single addresses query initially so most of its time is spent merging the addresses themselves.

I also got tired of waiting for the rake task and breaking VPN/SSH would stop it, so I think it will be best to run this in Sidekiq. My rake task would queue it for the whole org, but before I do that I'd queue a few manually to make sure they do what I expect and I'd monitor sidekiq in the process.