### PR TITLE
Org address merge single sidekiq job to not crowd others

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,8 +1,5 @@
 class Contact < ActiveRecord::Base
   include AddressMethods
-  include Async # To allow batch processing of address merges
-  include Sidekiq::Worker
-  sidekiq_options retry: false, unique: true
   acts_as_taggable
 
   has_paper_trail on: [:destroy, :update],

--- a/app/models/donor_account.rb
+++ b/app/models/donor_account.rb
@@ -1,9 +1,6 @@
 require_dependency 'address_methods'
 class DonorAccount < ActiveRecord::Base
   include AddressMethods
-  include Async # To allow batch processing of address merges
-  include Sidekiq::Worker
-  sidekiq_options retry: false, unique: true
 
   has_many :master_person_donor_accounts, dependent: :destroy
   has_many :master_people, through: :master_person_donor_accounts

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,4 +1,8 @@
 class Organization < ActiveRecord::Base
+  include Async # To allow batch processing of address merges
+  include Sidekiq::Worker
+  sidekiq_options retry: false, unique: true
+
   has_many :designation_accounts, dependent: :destroy
   has_many :designation_profiles, dependent: :destroy
   has_many :donor_accounts, dependent: :destroy
@@ -27,5 +31,21 @@ class Organization < ActiveRecord::Base
 
   def self.cru_usa
     Organization.find_by_code('CCC-USA')
+  end
+
+  # We had an organization, DiscipleMakers with a lot of duplicate addresses in its contacts and donor
+  # accounts due to a difference in how their data server donor import worked and a previous iteration of
+  # MPDX accepting duplicate addresses there. This will merge dup addresses in their donor accounts and
+  # contacts. The merging takes a while given the large number of duplicate addressees, so it made
+  # sense to run it as a single background job for the organizaton via Sidekiq/Async.
+  def merge_all_dup_addresses
+    donor_accounts.each(&:merge_addresses)
+
+    account_lists = AccountList.joins(:users)
+                      .joins('INNER JOIN person_organization_accounts ON person_organization_accounts.person_id = people.id')
+                      .where(person_organization_accounts: { organization_id: id })
+    account_lists.each do |account_list|
+      account_list.contacts.each(&:merge_addresses)
+    end
   end
 end


### PR DESCRIPTION
Yesterday I tried running the DiscipleMakers addresses merge with a bunch of sidekiq jobs for each donor account and contact. It got through some of them but because they were filling all Sidekiq threads, other jobs for MPDX got queued. This would make the org address merge a single job under Organization instead to allow the background workers to handle other MPDX jobs that come up.