### PR TITLE
Switch master address cleanup to count query

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -120,7 +120,7 @@ class Address < ActiveRecord::Base
   end
 
   def clean_up_master_address
-    master_address.destroy if master_address && (master_address.addresses - [self]).blank?
+    master_address.destroy if master_address && master_address.addresses.where.not(id: id).empty?
 
     true
   end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -18,4 +18,19 @@ describe Address do
       address.master_address == master_address
     end
   end
+
+  context '#clean_up_master_address' do
+    it 'cleans up the master address when destroyed if it is no longer needed by others' do
+      master = create(:master_address)
+      address1 = create(:address, master_address: master)
+      address2 = create(:address, master_address: master)
+      expect {
+        address1.destroy!
+      }.to_not change(MasterAddress, :count).from(1)
+
+      expect {
+        address2.destroy!
+      }.to change(MasterAddress, :count).from(1).to(0)
+    end
+  end
 end


### PR DESCRIPTION
I found a likely culprit to our address merge job running out of memory. When an address is destroyed it would query all the addresses associated with that master address (which could be like 1-2K for some larger DM donor accounts) and saves them associated with that destroyed address. Since we kept a list of those addresses (each of which had a list of all of them), the memory grew O(N^2). This would hopefully fix that as the destroyed addresses would just do a count query to check to see if cleanup is needed.