### PR TITLE
Google contact sync fix case for nil remote_id

### DIFF
--- a/app/models/google_contacts_integrator.rb
+++ b/app/models/google_contacts_integrator.rb
@@ -126,7 +126,7 @@ class GoogleContactsIntegrator
   end
 
   def delete_g_contact_merge_loser(g_contact_link)
-    api_user.delete_contact(g_contact_link.remote_id)
+    api_user.delete_contact(g_contact_link.remote_id) if g_contact_link.remote_id
     g_contact_link.destroy
   rescue => e
     if defined?(e.response) && GoogleContactsApi::Api.parse_response_code(e.response) == 404

--- a/spec/models/google_contacts_integrator_spec.rb
+++ b/spec/models/google_contacts_integrator_spec.rb
@@ -471,6 +471,16 @@ describe GoogleContactsIntegrator do
     end
   end
 
+  context '#delete_g_contact_merge_loser' do
+    it 'does not cause an error if the remote_id of the merge loser is nil' do
+      g_contact_link = create(:google_contact, remote_id: nil)
+      expect {
+        @integrator.delete_g_contact_merge_loser(g_contact_link)
+      }.to_not raise_error
+      expect(GoogleContact.count).to eq(0)
+    end
+  end
+
   describe 'sync behavior for merged MPDX contacts/people' do
     before do
       @contact.update_column(:notes, 'contact')


### PR DESCRIPTION
This fixes an error in errbit. It may be caused by a Google contact sync remote error message preventing the sync to complete so the remote_id gets set to nil.