### PR TITLE
Tnt preferred and valid field logic for phone/email, bug fix

### DIFF
--- a/app/assets/javascripts/contacts.js.coffee.erb
+++ b/app/assets/javascripts/contacts.js.coffee.erb
@@ -365,35 +365,34 @@ $ ->
         $('input[type=checkbox].primary', fieldset).prop('checked',false)
         $(this).prop('checked', true)
 
-    $(document).on 'click', 'input.address_historic', ->
-      historicAddressDisable this
-
-    historicAddressDisable = (check) ->
+    historicDisable = (check, input_selector) ->
       fieldset = $(check).closest(".rs")
       if $(check).is(":checked")
-        $("input[type=text], textarea, .country_select", fieldset).attr "readonly", true
+        $(input_selector, fieldset).attr "readonly", true
       else
-        $("input[type=text], textarea, .country_select", fieldset).removeAttr "readonly"
+        $(input_selector, fieldset).removeAttr "readonly"
       return
 
     $("input.address_historic").each ->
-      historicAddressDisable this
+      historicDisable this, "input[type=text], textarea, .country_select"
+      return
+
+    $(document).on 'click', 'input.address_historic', ->
+      historicDisable this, "input[type=text], textarea, .country_select"
+
+    $("input.email_historic").each ->
+      historicDisable this, "input[type=email]"
       return
 
     $(document).on 'click', 'input.email_historic', ->
-      historicEmailDisable this
+      historicDisable this, "input[type=email]"
 
-    historicEmailDisable = (check) ->
-      fieldset = $(check).closest(".rs")
-      if $(check).is(":checked")
-        $("input[type=email]", fieldset).attr "readonly", true
-      else
-        $("input[type=email]", fieldset).removeAttr "readonly"
+    $("input.phone_historic").each ->
+      historicDisable this, "input[type=tel]"
       return
 
-    $("input.email_historic").each ->
-      historicEmailDisable this
-      return
+    $(document).on 'click', 'input.phone_historic', ->
+      historicDisable(this, "input[type=tel]")
 
     $(document).on 'click', 'td.qaction a.quick', ->
       td = $(this).closest('td')

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -61,7 +61,7 @@ class Person < ActiveRecord::Base
       email_address: :email,
       phone_number: :number,
       email_addresses_attributes: [:email, :historic, :primary, :_destroy, :id],
-      phone_numbers_attributes: [:number, :location, :primary, :_destroy, :id],
+      phone_numbers_attributes: [:number, :location, :historic, :primary, :_destroy, :id],
       linkedin_accounts_attributes: [:url, :_destroy, :id],
       facebook_accounts_attributes: [:url, :_destroy, :id],
       twitter_accounts_attributes: [:screen_name, :_destroy, :id],

--- a/app/models/tnt_import.rb
+++ b/app/models/tnt_import.rb
@@ -105,7 +105,7 @@ class TntImport
     end
 
     merge_dups_by_donor_accts(contact, donor_accounts)
- d
+
     if true?(row['IsOrganization'])
       donor_accounts.each { |donor_account|  add_or_update_company(row, donor_account) }
     end
@@ -453,7 +453,10 @@ class TntImport
                    account_number: account_number,
                    padded_account_number: account_number.rjust(DONOR_NUMBER_NORMAL_LEN, '0')).first
 
-          unless da
+          if da
+            # Donor accounts for non-Cru orgs could have nil names so update with the name from tnt
+            da.update(name: row['FileAs']) if da.name.blank?
+          else
             da = designation_profile.organization.donor_accounts.new(account_number: account_number, name: row['FileAs'])
             da.addresses_attributes = build_address_array(row)
             da.save!

--- a/app/models/tnt_import.rb
+++ b/app/models/tnt_import.rb
@@ -413,17 +413,16 @@ class TntImport
 
     # If there is just a single email in Tnt, it leaves the suffix off, so start with a blank then do the numbers
     # up to three as Tnt allows a maximum of 3 email addresses for a person/spouse.
-    ['', '1', '2', '3'].each_with_index do |email_suffix, index|
-      email = row[prefix + "Email#{email_suffix}"]
+    (1..3).each do |email_num|
+      email = row[prefix + "Email#{email_num}"]
       next unless email.present?
 
-      email_valid = row[prefix + 'Email' + email_suffix + 'IsValid']
+      email_valid = row["#{prefix}Email#{email_num}IsValid"]
       historic = email_valid.present? && !true?(email_valid)
 
       email_attrs = { email: email, historic: historic }
 
       # For MPDX, we set the primary email to be the first "preferred" email listed in Tnt.
-      email_num = email_suffix == '' ? 1 : index
       if @import.override? && !found_primary && !historic && tnt_email_preferred?(row, email_num, prefix)
         person.email_addresses.each { |e| e.update(primary: false) }
         email_attrs[:primary] = true

--- a/app/models/tnt_import_util.rb
+++ b/app/models/tnt_import_util.rb
@@ -1,4 +1,30 @@
 module TntImportUtil
+  # This is an ordered array of the Tnt phone types. The order matters because the tnt  PreferredPhoneType
+  # is an index that into this list and the PhoneIsValidMask is a bit vector that refers to these in order too.
+  TNT_PHONES = [
+    { field: 'HomePhone', location: 'home', person: :both }, # index 0
+    { field: 'HomePhone2', location: 'home', person: :both },
+    { field: 'HomeFax', location: 'fax', person: :both },
+    { field: 'OtherPhone', location: 'other', person: :both },
+    { field: 'OtherFax', location: 'fax', person: :both },
+
+    { field: 'MobilePhone', location: 'mobile', person: :primary },
+    { field: 'MobilePhone2', location: 'mobile', person: :primary },
+    { field: 'PagerNumber', location: 'other', person: :primary },
+    { field: 'BusinessPhone', location: 'work', person: :primary },
+    { field: 'BusinessPhone2', location: 'work', person: :primary },
+    { field: 'BusinessFax', location: 'fax', person: :primary },
+    { field: 'CompanyMainPhone', location: 'work', person: :primary },
+
+    { field: 'SpouseMobilePhone', location: 'mobile', person: :spouse },
+    { field: 'SpouseMobilePhone2', location: 'mobile', person: :spouse },
+    { field: 'SpousePagerNumber', location: 'other', person: :spouse },
+    { field: 'SpouseBusinessPhone', location: 'work', person: :spouse },
+    { field: 'SpouseBusinessPhone2', location: 'work', person: :spouse },
+    { field: 'SpouseBusinessFax', location: 'fax', person: :spouse },
+    { field: 'SpouseCompanyMainPhone', location: 'work', person: :spouse } # index 18
+  ]
+
   def read_xml(import_file)
     xml = {}
     begin

--- a/app/serializers/phone_number_serializer.rb
+++ b/app/serializers/phone_number_serializer.rb
@@ -2,7 +2,7 @@ class PhoneNumberSerializer < ActiveModel::Serializer
   include DisplayCase::ExhibitsHelper
 
   embed :ids, include: true
-  ATTRIBUTES = [:id, :number, :country_code, :location, :primary, :created_at, :updated_at]
+  ATTRIBUTES = [:id, :number, :historic, :country_code, :location, :primary, :created_at, :updated_at]
   attributes(*ATTRIBUTES)
 
   def number

--- a/app/views/angular/contacts/contact.html.erb
+++ b/app/views/angular/contacts/contact.html.erb
@@ -12,7 +12,7 @@
         <div class="people">
             <div ng-repeat="i in contact.person_ids" ng-show="!getPerson(i).deceased">
               <a href="/people/{{i}}">{{getPerson(i).name}}</a>
-              <span ng-show="getPrimaryPhone(getPerson(i).id)" style="display:inline;"> - {{getPrimaryPhone(getPerson(i).id).number}} - {{getPrimaryPhone(getPerson(i).id).location}}</span>
+              <span ng-show="getPrimaryPhone(getPerson(i).id) && !getPrimaryPhone(getPerson(i).id).historic" style="display:inline;"> - {{getPrimaryPhone(getPerson(i).id).number}} - {{getPrimaryPhone(getPerson(i).id).location}}</span>
               <a ng-href="mailto:{{getEmailAddress(e).email}}" ng-repeat="e in getPerson(i).email_address_ids" ng-show="!getEmailAddress(e).historic"><i class="fa fa-envelope-square" title="Email"></i> </a>
               <a ng-href="https://www.facebook.com/{{getFacebookId(fb).remote_id}}" target="_blank" ng-repeat="fb in getPerson(i).facebook_account_ids"><i class="fa fa-facebook-square" title="Facebook profile"></i> </a>
             </div>

--- a/app/views/contacts/index.csv.erb
+++ b/app/views/contacts/index.csv.erb
@@ -41,6 +41,7 @@
 
     phone_numbers = contact.people.collect(&:phone_numbers).flatten[0..3]
     phone_numbers.each do |phone|
+      next if phone.historic?
       row << phone.number
     end
 

--- a/app/views/people/_contact_details_compact.html.erb
+++ b/app/views/people/_contact_details_compact.html.erb
@@ -1,8 +1,8 @@
 <div class="set phone">
   <% if person.phone_numbers.present? %>
-    <% person.phone_numbers.map {|pn| exhibit(pn, self)}.each do |phone_number| %>
-      <%= phone_number %>
-      <% if person.phone_numbers.length > 1 && phone_number.primary? %>
+    <% person.phone_numbers.map {|pn| exhibit(pn, self)}.each do |phone| next if phone.historic? %>
+      <%= phone %>
+      <% if person.phone_numbers.length > 1 && phone.primary? %>
         <i class="fa fa-check green"></i>
       <% end %>
       <br/>

--- a/app/views/people/_email_address_fields.html.erb
+++ b/app/views/people/_email_address_fields.html.erb
@@ -9,7 +9,7 @@
     </div>
     <div class="field_action">
       <%= builder.check_box :historic, class: 'email_historic' %>
-      <%= builder.label :historic, "Email address no longer valid" %>
+      <%= builder.label :historic, _('Email address no longer valid') %>
     </div>
   </div>
 </div>

--- a/app/views/people/_phone_number_fields.html.erb
+++ b/app/views/people/_phone_number_fields.html.erb
@@ -8,5 +8,9 @@
       <%= builder.label :primary %>
       <%= link_to_remove_fields(builder) %>
     </div>
+    <div class="field_action">
+      <%= builder.check_box :historic, class: 'phone_historic' %>
+      <%= builder.label :historic, _('Phone number no longer valid') %>
+    </div>
   </div>
 </div>

--- a/db/migrate/20150123123429_add_historic_to_phone_numbers.rb
+++ b/db/migrate/20150123123429_add_historic_to_phone_numbers.rb
@@ -1,0 +1,5 @@
+class AddHistoricToPhoneNumbers < ActiveRecord::Migration
+  def change
+    add_column :phone_numbers, :historic, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150106174739) do
+ActiveRecord::Schema.define(version: 20150123123429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -833,6 +833,7 @@ ActiveRecord::Schema.define(version: 20150106174739) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "remote_id"
+    t.boolean  "historic",     default: false
   end
 
   add_index "phone_numbers", ["person_id"], name: "index_phone_numbers_on_person_id", using: :btree

--- a/lib/google_contact_sync.rb
+++ b/lib/google_contact_sync.rb
@@ -291,8 +291,9 @@ module GoogleContactSync
 
   def compare_numbers_for_sync(g_contact, person, g_contact_link)
     last_sync_numbers = g_contact_link.last_data[:phone_numbers].map { |p| p[:number] }
-    compare_normalized_for_sync(last_sync_numbers, person.phone_numbers.map(&:number), g_contact.phone_numbers,
-                                method(:normalize_number))
+    compare_normalized_for_sync(last_sync_numbers, person.phone_numbers.where(historic: false).pluck(:number),
+                                g_contact.phone_numbers, method(:normalize_number),
+                                person.phone_numbers.where(historic: true).pluck(:number))
   end
 
   def compare_addresses_for_sync(g_contact_addresses, contact, last_addresses)

--- a/spec/factories/imports.rb
+++ b/spec/factories/imports.rb
@@ -44,4 +44,9 @@ FactoryGirl.define do
     association :account_list
     file { File.new(Rails.root.join('spec/fixtures/tnt/tnt_export_gifts_1added.xml')) }
   end
+
+  factory :tnt_import_first_email_not_preferred, parent: :tnt_import do
+    association :account_list
+    file { File.new(Rails.root.join('spec/fixtures/tnt/tnt_row_multi_email.yaml')) }
+  end
 end

--- a/spec/fixtures/tnt/tnt_export.xml
+++ b/spec/fixtures/tnt/tnt_export.xml
@@ -66,10 +66,12 @@ Nowhere, CA  12345</HomeAddressBlock>
         <SpouseBusinessAddressIsDeliverable>false</SpouseBusinessAddressIsDeliverable>
         <SpouseBusinessAddressBlockIsCustom>false</SpouseBusinessAddressBlockIsCustom>
         <PreferredPhoneType>0</PreferredPhoneType>
-        <PhoneIsValidMask>1</PhoneIsValidMask>
+        <PhoneIsValidMask>4385</PhoneIsValidMask>
         <PhoneCountryIDs>0=840</PhoneCountryIDs>
         <HomePhone>(555) 555-1234</HomePhone>
+        <MobilePhone>111-111-1111</MobilePhone>
         <BusinessPhone>(555) 555-9771 ext. 301</BusinessPhone>
+        <SpouseMobilePhone>222-222-2222</SpouseMobilePhone>
         <PreferredEmailTypes>0</PreferredEmailTypes>
         <Email1IsValid>false</Email1IsValid>
         <Email2IsValid>false</Email2IsValid>
@@ -187,7 +189,7 @@ State, CA  12345</HomeAddressBlock>
         <PhoneIsValidMask>1</PhoneIsValidMask>
         <PhoneCountryIDs>0=840</PhoneCountryIDs>
         <HomePhone>(555) 234-2345</HomePhone>
-        <PreferredEmailTypes>0</PreferredEmailTypes>
+        <PreferredEmailTypes>2</PreferredEmailTypes>
         <Email1>fake@example.com</Email1>
         <Email2>fake@example.com</Email2>
         <Email1IsValid>true</Email1IsValid>

--- a/spec/fixtures/tnt/tnt_export.xml
+++ b/spec/fixtures/tnt/tnt_export.xml
@@ -31,7 +31,8 @@ Nowhere, CA  12345</MailingAddressBlock>
         <MailingAddressIsDeliverable>true</MailingAddressIsDeliverable>
         <Phone>(555) 555-1234</Phone>
         <PhoneIsValid>true</PhoneIsValid>
-        <EmailIsValid>false</EmailIsValid>
+        <Email>same@example.com</Email>
+        <EmailIsValid>true</EmailIsValid>
         <IsOrganization>false</IsOrganization>
         <FirstName>John</FirstName>
         <LastName>Smith</LastName>
@@ -72,9 +73,11 @@ Nowhere, CA  12345</HomeAddressBlock>
         <MobilePhone>111-111-1111</MobilePhone>
         <BusinessPhone>(555) 555-9771 ext. 301</BusinessPhone>
         <SpouseMobilePhone>222-222-2222</SpouseMobilePhone>
-        <PreferredEmailTypes>0</PreferredEmailTypes>
-        <Email1IsValid>false</Email1IsValid>
-        <Email2IsValid>false</Email2IsValid>
+        <PreferredEmailTypes>3</PreferredEmailTypes>
+        <Email1>same@example.com</Email1>
+        <Email2>same@example.com</Email2>
+        <Email1IsValid>true</Email1IsValid>
+        <Email2IsValid>true</Email2IsValid>
         <Email3IsValid>false</Email3IsValid>
         <SpouseEmail1IsValid>false</SpouseEmail1IsValid>
         <SpouseEmail2IsValid>false</SpouseEmail2IsValid>
@@ -185,13 +188,14 @@ State, CA  12345</HomeAddressBlock>
         <SpouseBusinessCountry>United States of America</SpouseBusinessCountry>
         <SpouseBusinessAddressIsDeliverable>false</SpouseBusinessAddressIsDeliverable>
         <SpouseBusinessAddressBlockIsCustom>false</SpouseBusinessAddressBlockIsCustom>
-        <PreferredPhoneType>0</PreferredPhoneType>
-        <PhoneIsValidMask>1</PhoneIsValidMask>
+        <PreferredPhoneType>3</PreferredPhoneType>
+        <PhoneIsValidMask>9</PhoneIsValidMask>
         <PhoneCountryIDs>0=840</PhoneCountryIDs>
         <HomePhone>(555) 234-2345</HomePhone>
-        <PreferredEmailTypes>2</PreferredEmailTypes>
+        <OtherPhone>222-333-7890</OtherPhone>
+        <PreferredEmailTypes>4</PreferredEmailTypes>
         <Email1>fake@example.com</Email1>
-        <Email2>fake@example.com</Email2>
+        <Email2>fake2@example.com</Email2>
         <Email1IsValid>true</Email1IsValid>
         <Email2IsValid>true</Email2IsValid>
         <Email3IsValid>false</Email3IsValid>

--- a/spec/fixtures/tnt/tnt_row_multi_email.yaml
+++ b/spec/fixtures/tnt/tnt_row_multi_email.yaml
@@ -1,0 +1,105 @@
+---
+id: '1360433356'
+LastEdit: '2014-09-24 20:29:18'
+CreatedDate: '2009-01-15'
+FileAs: Doe, John and Jane
+FileAsIsCustom: 'false'
+FullName: John and Jane Doe
+FullNameIsCustom: 'false'
+Greeting: John and Jane
+GreetingIsCustom: 'false'
+Salutation: Dear John and Jane,
+SalutationIsCustom: 'false'
+ShortName: John and Jane Doe
+ShortNameIsCustom: 'false'
+MailingAddressBlock: John and Jane Doe\nSC
+MailingAddressIsDeliverable: 'false'
+Phone: "(123) 345-7655"
+PhoneIsValid: 'true'
+Email: JohnF@nhcconline.com
+EmailIsValid: 'true'
+IsOrganization: 'false'
+FirstName: John
+LastName: Doe
+SpouseFirstName: Jane
+Deceased: 'false'
+MailingAddressType: '1'
+MailingState: SC
+HomeState: SC
+HomeCountryID: '840'
+HomeCountry: United States of America
+HomeAddressIsDeliverable: 'false'
+HomeAddressBlock: John and Jane Doe\nSC
+HomeAddressBlockIsCustom: 'false'
+OtherCountryID: '840'
+OtherCountry: United States of America
+OtherAddressIsDeliverable: 'false'
+OtherAddressBlockIsCustom: 'false'
+BusinessCountryID: '840'
+BusinessCountry: United States of America
+BusinessAddressIsDeliverable: 'false'
+BusinessAddressBlockIsCustom: 'false'
+SpouseBusinessCountryID: '840'
+SpouseBusinessCountry: United States of America
+SpouseBusinessAddressIsDeliverable: 'false'
+SpouseBusinessAddressBlockIsCustom: 'false'
+PreferredPhoneType: '5'
+PhoneIsValidMask: '32'
+PhoneCountryIDs: 5=840
+MobilePhone: "(123) 235-7655"
+PreferredEmailTypes: '4'
+Email1: John.Doe@charter.net
+Email2: JohnF@nhcconline.com
+Email1IsValid: 'true'
+Email2IsValid: 'true'
+Email3IsValid: 'false'
+SpouseEmail1IsValid: 'false'
+SpouseEmail2IsValid: 'false'
+SpouseEmail3IsValid: 'false'
+NotesAsRTF: "{\\rtf1\\ansi\\deff0{\\fonttbl{\\f0\\fnil\\fcharset0 Tahoma;}{\\f1\\fnil
+  Tahoma;}}\\n{\\*\\generator Msftedit 5.41.15.1515;}\\viewkind4\\uc1\\pard\\lang1033\\f0\\fs16
+  Elder \\f1\\par\\n}"
+Notes: Elder
+FamilySideID: '0'
+FamilyLevelID: '0'
+Children: 3-4
+PledgeAmount: '0'
+PledgeFrequencyID: '0'
+PledgeReceived: 'false'
+PledgeStartDate: '1899-12-30'
+ReferredBy: Cronins
+ReferredByList: Cronins
+MPDPhaseID: '20'
+NextAsk: '1899-12-30'
+NeverAsk: 'false'
+Region: South Carolina
+LikelyToGiveID: '0'
+ChurchName: North
+SendNewsletter: 'false'
+NewsletterMediaPref: "+P-E"
+DirectDeposit: 'false'
+Magazine: 'false'
+MonthlyPledge: '0'
+FirstGiftDate: '1899-12-30'
+LastGiftDate: '1899-12-30'
+LastGiftAmount: '0'
+LastGiftOrganizationID: '0'
+PrevYearTotal: '0'
+YearTotal: '0'
+LifetimeTotal: '0'
+LifetimeNumberOfGifts: '0'
+LargestGift: '0'
+GoodUntil: '1899-12-30'
+AveMonthlyGift: '0'
+LastDateInAve: '1899-12-30'
+TwelveMonthTotal: '0'
+LastActivity: '2013-03-19'
+LastAppointment: '1899-12-30'
+LastCall: '1899-12-30'
+LastPreCall: '1899-12-30'
+LastLetter: '2013-03-19'
+LastVisit: '1899-12-30'
+LastThank: '1899-12-30'
+LastChallenge: '1899-12-30'
+AppealsSinceLastGift: '0'
+ChallengesSinceLastGift: '0'

--- a/spec/lib/google_contact_sync_spec.rb
+++ b/spec/lib/google_contact_sync_spec.rb
@@ -255,6 +255,7 @@ describe GoogleContactSync do
   describe 'sync numbers' do
     it 'combines and formats numbers from mpdx and google' do
       person.phone_number = { number: '+12223334444', location: 'mobile', primary: true }
+      person.save
 
       g_contact.update('gd$phoneNumber' => [
         { '$t' => '(777) 888-9999', 'primary' => 'true', 'rel' => 'http://schemas.google.com/g/2005#other' }
@@ -266,8 +267,6 @@ describe GoogleContactSync do
         { number: '(777) 888-9999', primary: true, rel: 'other' },
         { number: '(222) 333-4444', primary: false, rel: 'mobile' }
       ])
-
-      person.save
 
       expect(person.phone_numbers.count).to eq(2)
       phone1 = person.phone_numbers.first
@@ -500,6 +499,15 @@ describe GoogleContactSync do
       person.save!
       expect(sync).to receive(:compare_considering_historic).with([], [], [], ['a@a.co']).and_return('compared')
       expect(sync.compare_emails_for_sync(g_contact, person, g_contact_link)).to eq('compared')
+    end
+  end
+
+  describe 'compare_numbers_for_sync' do
+    it 'uses historic list for comparision' do
+      person.phone_numbers << build(:phone_number, number: '+12223334444', historic: true)
+      person.save!
+      expect(sync).to receive(:compare_considering_historic).with([], [], [], ['+12223334444']).and_return('compared')
+      expect(sync.compare_numbers_for_sync(g_contact, person, g_contact_link)).to eq('compared')
     end
   end
 

--- a/spec/models/tnt_import_spec.rb
+++ b/spec/models/tnt_import_spec.rb
@@ -182,6 +182,15 @@ describe TntImport do
       end
     end
 
+    it 'imports a contact even if their donor account had no name', debug: true do
+      org = create(:organization)
+      create(:donor_account, account_number: '413518908', organization: org, name: nil)
+      create(:designation_profile, account_list: tnt_import.account_list, organization: org)
+      expect {
+        import.send(:import_contacts)
+      }.to change(Contact, :count).by(2)
+    end
+
     it 'imports a contact people details even if the contact is not a donor' do
       import = TntImport.new(create(:tnt_import_non_donor))
       expect {

--- a/spec/models/tnt_import_spec.rb
+++ b/spec/models/tnt_import_spec.rb
@@ -332,13 +332,14 @@ describe TntImport do
   context '#update_person_phones' do
     let(:person) { create(:person) }
 
-    it 'does not import invalid phone numbers' do
+    it 'marks tnt "invalid" phone numbers as historic in mpdx' do
       row = { 'HomePhone2' => '222-222-2222', 'SpouseMobilePhone' => '333-333-3333',
         'PhoneIsValidMask' => '4096' }
       prefix = 'Spouse'
       import.send(:update_person_phones, person, row, prefix)
-      expect(person.phone_numbers.count).to eq(1)
-      expect(person.phone_numbers.first.number).to eq('+13333333333')
+      expect(person.phone_numbers.count).to eq(2)
+      expect(person.phone_numbers.map { |p| [p.number, p.historic] }).to include(['+12222222222', true])
+      expect(person.phone_numbers.map { |p| [p.number, p.historic] }).to include(['+13333333333', false])
     end
   end
 


### PR DESCRIPTION
This improves / corrects the logic of the Tnt import for preferred and valid emails and phone numbers. If the import is set to override it will also override the existing primary phone/email in MPDX and will not if not. This also fixes a bug for the case (presumably only for non-Cru orgs) where a Tnt contact import would not work if the existing corresponding donor account had a blank name.