### PR TITLE
Data server dup address fix for alternate country names

### DIFF
--- a/app/concerns/address_methods.rb
+++ b/app/concerns/address_methods.rb
@@ -13,8 +13,10 @@ module AddressMethods
 
   def blank_or_duplicate_address?(attributes)
     return false if attributes['id']
-    attributes.slice('street', 'city', 'state', 'country', 'postal_code', :street, :city, :state, :country, :postal_code).all? { |_, v| v.blank? } ||
-    addresses.where(attributes.slice('street', 'city', 'state', 'country', 'postal_code', :street, :city, :state, :country, :postal_code)).first.present?
+
+    place_attrs = attributes.symbolize_keys.slice(:street, :city, :state, :country, :postal_code)
+    place_attrs[:country] = Address.normalize_country(place_attrs[:country])
+    place_attrs.all? { |_, v| v.blank? } || !addresses.where(place_attrs).empty?
   end
 
   def address

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -53,23 +53,24 @@ class Address < ActiveRecord::Base
   end
 
   def country=(val)
-    if val.blank?
-      self[:country] = val
-      return
-    end
+    self[:country] = self.class.normalize_country(val)
+  end
+
+  def self.normalize_country(val)
+    return val if val.blank?
 
     countries = CountrySelect::COUNTRIES
-    if country = countries.find { |c| c[:name].downcase == val.downcase }
-      self[:country] = country[:name]
-    else
-      countries.each do |c|
-        next unless c[:alternatives].downcase.include?(val.downcase)
-        self[:country] = c[:name]
-        return
-      end
-      # If we couldn't find a match anywhere, go ahead and save it anyway
-      self[:country] = val
+
+    country = countries.find { |c| c[:name].downcase == val.downcase }
+    return country[:name] if country
+
+    countries.each do |c|
+      next unless c[:alternatives].downcase.include?(val.downcase)
+      return c[:name]
     end
+
+    # If we couldn't find a match anywhere, go ahead and return the country
+    val
   end
 
   def valid_mailing_address?

--- a/spec/concerns/address_methods_spec.rb
+++ b/spec/concerns/address_methods_spec.rb
@@ -4,31 +4,62 @@ describe AddressMethods do
   let(:contact) { create(:contact) }
   let(:donor_account) { create(:donor_account) }
 
-  def expect_merge_addresses_works(addressable)
-    address1 = create(:address, street: '1 Way', master_address_id: 1)
-    address2 = create(:address, street: '1 Way', master_address_id: 1)
-    address3 = create(:address, street: '2 Way', master_address_id: 2)
-    addressable.addresses << address1
-    addressable.addresses << address2
-    addressable.addresses << address3
+  context '#merge_addresses' do
+    def expect_merge_addresses_works(addressable)
+      address1 = create(:address, street: '1 Way', master_address_id: 1)
+      address2 = create(:address, street: '1 Way', master_address_id: 1)
+      address3 = create(:address, street: '2 Way', master_address_id: 2)
+      addressable.addresses << address1
+      addressable.addresses << address2
+      addressable.addresses << address3
 
-    expect {
-      addressable.merge_addresses
+      expect {
+        addressable.merge_addresses
 
-    }.to change(Address, :count).from(3).to(2)
+      }.to change(Address, :count).from(3).to(2)
 
-    expect(Address.find_by_id(address1.id)).to be_nil
-    expect(Address.find_by_id(address2.id)).to eq(address2)
-    expect(Address.find_by_id(address3.id)).to eq(address3)
-  end
+      expect(Address.find_by_id(address1.id)).to be_nil
+      expect(Address.find_by_id(address2.id)).to eq(address2)
+      expect(Address.find_by_id(address3.id)).to eq(address3)
+    end
 
-  describe '#merge_addresses' do
     it 'works for contact' do
       expect_merge_addresses_works(contact)
     end
 
     it 'works for donor_account' do
       expect_merge_addresses_works(donor_account)
+    end
+  end
+
+  context '#blank_or_duplicate_address?' do
+    it 'returns false if an id specified' do
+      expect(contact.blank_or_duplicate_address?('id' => '1')).to be_false
+    end
+
+    it 'returns true if address fields blank' do
+      expect(contact.blank_or_duplicate_address?({})).to be_true
+    end
+
+    it 'returns false if any address field is specified' do
+      ['street', 'city', 'state', 'country', 'postal_code', :street, :city, :state, :country, :postal_code].each do |field|
+        expect(contact.blank_or_duplicate_address?(field => 'a')).to be_false
+      end
+    end
+
+    it 'returns true for a duplicate address by by matching attributes, false if not matching' do
+      a = create(:address)
+      contact.addresses << a
+      expect(contact.blank_or_duplicate_address?(street: a.street, city: a.city, country: a.country,
+                                                 postal_code: a.postal_code)).to be_true
+      expect(contact.blank_or_duplicate_address?(street: 'other street')).to be_false
+    end
+
+    it 'returns true for a duplicate address by by matching attributes if country set alternate name' do
+      a = create(:address, country: 'USA')
+      contact.addresses << a
+      expect(contact.blank_or_duplicate_address?(street: a.street, city: a.city, country: 'USA',
+                                                 postal_code: a.postal_code)).to be_true
     end
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -33,4 +33,32 @@ describe Address do
       }.to change(MasterAddress, :count).from(1).to(0)
     end
   end
+
+  context '#country=' do
+    it 'normalizes the country when assigned' do
+      address = build(:address)
+      expect(Address).to receive(:normalize_country).with('USA').and_return('United States')
+      address.country = 'USA'
+      expect(address.country).to eq('United States')
+    end
+  end
+
+  context '#normalize_country' do
+    it 'returns passed in arg if given blank' do
+      expect(Address.normalize_country('')).to eq('')
+      expect(Address.normalize_country(nil)).to be_nil
+    end
+
+    it 'normalizes country by case' do
+      expect(Address.normalize_country('united STATES')).to eq('United States')
+    end
+
+    it 'normalizes by alternate country name' do
+      expect(Address.normalize_country('uSa')).to eq('United States')
+    end
+
+    it 'returns a country not in the list as is' do
+      expect(Address.normalize_country('Some non-Existent country')).to eq('Some non-Existent country')
+    end
+  end
 end


### PR DESCRIPTION
The DiscipleMakers organization was still getting duplicate addresses. The duplicate address check for new addresses didn't work if the address used an alternate country name like 'USA' instead of the normalized name in the database of 'United States'.