### PR TITLE
Master address improvements

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -10,8 +10,7 @@ class Address < ActiveRecord::Base
 
   scope :current, -> { where(deleted: false) }
 
-  before_create :find_or_create_master_address
-  before_update :update_or_create_master_address
+  before_validation :determine_master_address
   after_destroy :clean_up_master_address
   after_save :update_contact_timezone
 
@@ -106,6 +105,14 @@ class Address < ActiveRecord::Base
   end
 
   private
+
+  def determine_master_address
+    if id.blank?
+      find_or_create_master_address
+    else
+      update_or_create_master_address
+    end
+  end
 
   def update_or_create_master_address
     if (changed & %w(street city state country postal_code)).present?

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -18,8 +18,6 @@ class Address < ActiveRecord::Base
 
   attr_accessor :user_changed
 
-  validates :master_address_id, presence: true
-
   assignable_values_for :location, allow_blank: true do
     [_('Home'), _('Business'), _('Mailing'), _('Other')]
   end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -17,6 +17,10 @@ class Address < ActiveRecord::Base
 
   alias_method :destroy!, :destroy
 
+  attr_accessor :user_changed
+
+  validates :master_address_id, presence: true
+
   assignable_values_for :location, allow_blank: true do
     [_('Home'), _('Business'), _('Mailing'), _('Other')]
   end
@@ -105,6 +109,8 @@ class Address < ActiveRecord::Base
 
   def update_or_create_master_address
     if (changed & %w(street city state country postal_code)).present?
+      self.remote_id = nil if user_changed
+
       new_master_address_match = find_master_address
 
       if master_address.nil? || master_address != new_master_address_match

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -50,7 +50,7 @@ class Contact < ActiveRecord::Base
       donor_accounts_attributes: [:account_number, :organization_id, :_destroy, :id],
       addresses_attributes: [
         :remote_id, :master_address_id, :location, :street, :city, :state, :postal_code, :region, :metro_area,
-        :country, :historic, :primary_mailing_address, :_destroy, :id
+        :country, :historic, :primary_mailing_address, :_destroy, :id, :user_changed
       ],
       people_attributes: Person::PERMITTED_ATTRIBUTES
     }

--- a/app/models/contact_filter.rb
+++ b/app/models/contact_filter.rb
@@ -101,6 +101,7 @@ class ContactFilter
           filtered_contacts = filtered_contacts.where("send_newsletter is null OR send_newsletter = ''")
         when 'address'
           filtered_contacts = filtered_contacts.joins(:addresses).where(send_newsletter: %w(Physical Both))
+                                               .where('addresses.historic' => false)
         when 'email'
           filtered_contacts = filtered_contacts.where(send_newsletter: %w(Email Both))
                                                .where('email_addresses.email is not null')

--- a/app/views/contacts/_address_fields.html.erb
+++ b/app/views/contacts/_address_fields.html.erb
@@ -1,6 +1,5 @@
 <div class="sfield address_field" data-behavior="field-wrapper">
-  <%= builder.hidden_field :remote_id, value: '' %>
-  <%= builder.hidden_field :master_address_id, value: '' %>
+  <%= builder.hidden_field :user_changed, value: true %>
   <div class="ls">
     <%= builder.label :location %>
     <%= builder.select :location, builder.object.assignable_locations.collect { |l| [_(l), l] }, include_blank: true %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,8 +38,6 @@ module Mpdx
 
     #config.log_tags = [ :uuid, :remote_ip ]
 
-    config.active_record.disable_implicit_join_references = true
-
     config.exceptions_app = self.routes
   end
 end

--- a/db/migrate/20150202221959_add_master_address_id_constraint.rb
+++ b/db/migrate/20150202221959_add_master_address_id_constraint.rb
@@ -1,7 +1,8 @@
 class AddMasterAddressIdConstraint < ActiveRecord::Migration
   def change
-    Address.where(master_address_id: nil).each do |address|
+    Address.where(master_address_id: nil).find_each(batch_size: 500) do |address|
       address.find_or_create_master_address
+      address.save!
     end
 
     change_column_null :addresses, :master_address_id, false

--- a/db/migrate/20150202221959_add_master_address_id_constraint.rb
+++ b/db/migrate/20150202221959_add_master_address_id_constraint.rb
@@ -1,0 +1,9 @@
+class AddMasterAddressIdConstraint < ActiveRecord::Migration
+  def change
+    Address.where(master_address_id: nil).each do |address|
+      address.find_or_create_master_address
+    end
+
+    change_column_null :addresses, :master_address_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150123123429) do
+ActiveRecord::Schema.define(version: 20150202221959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,8 +19,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "account_list_entries", force: true do |t|
     t.integer  "account_list_id"
     t.integer  "designation_account_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "account_list_entries", ["account_list_id", "designation_account_id"], name: "unique_account", unique: true, using: :btree
@@ -29,8 +29,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "account_list_users", force: true do |t|
     t.integer  "user_id"
     t.integer  "account_list_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   add_index "account_list_users", ["account_list_id"], name: "index_account_list_users_on_account_list_id", using: :btree
@@ -39,12 +39,27 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "account_lists", force: true do |t|
     t.string   "name"
     t.integer  "creator_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text     "settings"
   end
 
   add_index "account_lists", ["creator_id"], name: "index_account_lists_on_creator_id", using: :btree
+
+  create_table "active_admin_comments", force: true do |t|
+    t.string   "resource_id",   null: false
+    t.string   "resource_type", null: false
+    t.integer  "author_id"
+    t.string   "author_type"
+    t.text     "body"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.string   "namespace"
+  end
+
+  add_index "active_admin_comments", ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
+  add_index "active_admin_comments", ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
+  add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_admin_notes_on_resource_type_and_resource_id", using: :btree
 
   create_table "activities", force: true do |t|
     t.integer  "account_list_id"
@@ -54,8 +69,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.datetime "start_at"
     t.datetime "end_at"
     t.string   "type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                           null: false
+    t.datetime "updated_at",                                           null: false
     t.boolean  "completed",                            default: false, null: false
     t.integer  "activity_comments_count",              default: 0
     t.string   "activity_type"
@@ -76,8 +91,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "activity_id"
     t.integer  "person_id"
     t.text     "body"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   add_index "activity_comments", ["activity_id"], name: "index_activity_comments_on_activity_id", using: :btree
@@ -86,8 +101,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "activity_contacts", force: true do |t|
     t.integer  "activity_id"
     t.integer  "contact_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   add_index "activity_contacts", ["activity_id", "contact_id"], name: "index_activity_contacts_on_activity_id_and_contact_id", using: :btree
@@ -104,13 +119,13 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "location"
     t.date     "start_date"
     t.date     "end_date"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
     t.boolean  "primary_mailing_address", default: false
     t.string   "addressable_type"
     t.string   "remote_id"
     t.boolean  "seasonal",                default: false
-    t.integer  "master_address_id"
+    t.integer  "master_address_id",                       null: false
     t.boolean  "verified",                default: false, null: false
     t.boolean  "deleted",                 default: false, null: false
     t.string   "region"
@@ -118,9 +133,26 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.boolean  "historic",                default: false
   end
 
-  add_index "addresses", ["addressable_id"], name: "index_addresses_on_addressable_id", using: :btree
+  add_index "addresses", ["addressable_id"], name: "index_addresses_on_person_id", using: :btree
   add_index "addresses", ["master_address_id"], name: "index_addresses_on_master_address_id", using: :btree
   add_index "addresses", ["remote_id"], name: "index_addresses_on_remote_id", using: :btree
+
+  create_table "admin_users", force: true do |t|
+    t.string   "email",                default: "", null: false
+    t.string   "guid",                              null: false
+    t.integer  "sign_in_count",        default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.string   "authentication_token"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+  end
+
+  add_index "admin_users", ["authentication_token"], name: "index_admin_users_on_authentication_token", unique: true, using: :btree
+  add_index "admin_users", ["email"], name: "index_admin_users_on_email", unique: true, using: :btree
+  add_index "admin_users", ["guid"], name: "index_admin_users_on_guid", unique: true, using: :btree
 
   create_table "appeal_contacts", force: true do |t|
     t.integer  "appeal_id"
@@ -147,8 +179,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
 
   create_table "companies", force: true do |t|
     t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
     t.text     "street"
     t.string   "city"
     t.string   "state"
@@ -161,8 +193,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "company_partnerships", force: true do |t|
     t.integer  "account_list_id"
     t.integer  "company_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   add_index "company_partnerships", ["account_list_id", "company_id"], name: "unique_company_account", unique: true, using: :btree
@@ -174,8 +206,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.date     "start_date"
     t.date     "end_date"
     t.string   "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "company_positions", ["company_id"], name: "index_company_positions_on_company_id", using: :btree
@@ -185,8 +217,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "contact_donor_accounts", force: true do |t|
     t.integer  "contact_id"
     t.integer  "donor_account_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
   end
 
   add_index "contact_donor_accounts", ["contact_id"], name: "index_contact_donor_accounts_on_contact_id", using: :btree
@@ -196,8 +228,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "contact_id"
     t.integer  "person_id"
     t.boolean  "primary"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "contact_people", ["contact_id", "person_id"], name: "index_contact_people_on_contact_id_and_person_id", unique: true, using: :btree
@@ -206,8 +238,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "contact_referrals", force: true do |t|
     t.integer  "referred_by_id"
     t.integer  "referred_to_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
   end
 
   add_index "contact_referrals", ["referred_by_id", "referred_to_id"], name: "referrals", using: :btree
@@ -216,8 +248,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "contacts", force: true do |t|
     t.string   "name"
     t.integer  "account_list_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                                                    null: false
+    t.datetime "updated_at",                                                                    null: false
     t.decimal  "pledge_amount",                        precision: 8,  scale: 2
     t.string   "status"
     t.decimal  "total_donations",                      precision: 10, scale: 2
@@ -247,7 +279,7 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "tnt_id"
     t.string   "not_duplicated_with",     limit: 2000
     t.integer  "uncompleted_tasks_count",                                       default: 0,     null: false
-    t.string   "prayer_letters_id"
+    t.string   "prayer_letters_id",       limit: 100
     t.string   "timezone"
     t.string   "envelope_greeting"
   end
@@ -259,10 +291,10 @@ ActiveRecord::Schema.define(version: 20150123123429) do
 
   create_table "designation_accounts", force: true do |t|
     t.string   "designation_number"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
     t.integer  "organization_id"
-    t.decimal  "balance",            precision: 8, scale: 2
+    t.decimal  "balance",            precision: 19, scale: 2
     t.datetime "balance_updated_at"
     t.string   "name"
     t.string   "staff_account_id"
@@ -274,21 +306,21 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "designation_profile_accounts", force: true do |t|
     t.integer  "designation_profile_id"
     t.integer  "designation_account_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "designation_profile_accounts", ["designation_profile_id", "designation_account_id"], name: "designation_p_to_a", unique: true, using: :btree
 
   create_table "designation_profiles", force: true do |t|
     t.string   "remote_id"
-    t.integer  "user_id",                                    null: false
-    t.integer  "organization_id",                            null: false
+    t.integer  "user_id",                                     null: false
+    t.integer  "organization_id",                             null: false
     t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
     t.string   "code"
-    t.decimal  "balance",            precision: 8, scale: 2
+    t.decimal  "balance",            precision: 19, scale: 2
     t.datetime "balance_updated_at"
     t.integer  "account_list_id"
   end
@@ -309,8 +341,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.decimal  "amount",                 precision: 8, scale: 2
     t.text     "memo"
     t.date     "donation_date"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
     t.string   "payment_type"
     t.string   "channel"
     t.integer  "appeal_id"
@@ -325,8 +357,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "donor_account_people", force: true do |t|
     t.integer  "donor_account_id"
     t.integer  "person_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
   end
 
   add_index "donor_account_people", ["donor_account_id"], name: "index_donor_account_people_on_donor_account_id", using: :btree
@@ -336,8 +368,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "organization_id"
     t.string   "account_number"
     t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                              null: false
+    t.datetime "updated_at",                                              null: false
     t.integer  "master_company_id"
     t.decimal  "total_donations",                precision: 10, scale: 2
     t.date     "last_donation_date"
@@ -354,11 +386,12 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "person_id"
     t.string   "email",                                 null: false
     t.boolean  "primary",               default: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.string   "remote_id"
     t.string   "location",   limit: 50
     t.boolean  "historic",              default: false
+    t.boolean  "bad",                   default: false, null: false
   end
 
   add_index "email_addresses", ["email", "person_id"], name: "index_email_addresses_on_email_and_person_id", unique: true, using: :btree
@@ -368,9 +401,9 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "family_relationships", force: true do |t|
     t.integer  "person_id"
     t.integer  "related_person_id"
-    t.string   "relationship",      null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string   "relationship"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
   end
 
   add_index "family_relationships", ["person_id", "related_person_id"], name: "index_family_relationships_on_person_id_and_related_person_id", unique: true, using: :btree
@@ -448,8 +481,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.text     "user_preferences"
     t.text     "account_list_settings"
     t.string   "request_type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
   end
 
   create_table "imports", force: true do |t|
@@ -457,8 +490,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "source"
     t.string   "file"
     t.boolean  "importing"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.text     "tags"
     t.boolean  "override",          default: false, null: false
     t.integer  "user_id"
@@ -477,8 +510,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "grouping_id"
     t.string   "primary_list_id"
     t.integer  "account_list_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
   end
 
   add_index "mail_chimp_accounts", ["account_list_id"], name: "index_mail_chimp_accounts_on_account_list_id", using: :btree
@@ -491,29 +524,29 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "postal_code"
     t.boolean  "verified",        default: false, null: false
     t.text     "smarty_response"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
   end
 
   add_index "master_addresses", ["street", "city", "state", "country", "postal_code"], name: "all_fields", using: :btree
 
   create_table "master_companies", force: true do |t|
     t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "master_people", force: true do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "master_person_donor_accounts", force: true do |t|
     t.integer  "master_person_id"
     t.integer  "donor_account_id"
     t.boolean  "primary",          default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
   end
 
   add_index "master_person_donor_accounts", ["donor_account_id"], name: "index_master_person_donor_accounts_on_donor_account_id", using: :btree
@@ -523,8 +556,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "master_person_id"
     t.integer  "organization_id"
     t.string   "remote_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
   end
 
   add_index "master_person_sources", ["master_person_id"], name: "index_master_person_sources_on_master_person_id", using: :btree
@@ -540,8 +573,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "remote_id"
     t.integer  "contact_id"
     t.integer  "account_list_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   add_index "messages", ["account_list_id"], name: "index_messages_on_account_list_id", using: :btree
@@ -578,8 +611,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "notification_type_id"
     t.integer  "account_list_id"
     t.text     "actions"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
   end
 
   add_index "notification_preferences", ["account_list_id"], name: "index_notification_preferences_on_account_list_id", using: :btree
@@ -588,8 +621,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   create_table "notification_types", force: true do |t|
     t.string   "type"
     t.text     "description"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
     t.text     "description_for_email"
   end
 
@@ -598,8 +631,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "notification_type_id"
     t.datetime "event_date"
     t.boolean  "cleared",              default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.integer  "donation_id"
   end
 
@@ -637,8 +670,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "profiles_url"
     t.string   "profiles_params"
     t.string   "redirect_query_ini"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.string   "api_class"
   end
 
@@ -664,8 +697,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
     t.integer  "master_person_id",                                   null: false
     t.string   "middle_name"
     t.string   "access_token",          limit: 32
@@ -688,8 +721,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "remote_id",        limit: 8,                 null: false
     t.string   "token"
     t.datetime "token_expires_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
     t.boolean  "valid_token",                default: false
     t.string   "first_name"
     t.string   "last_name"
@@ -708,8 +741,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "refresh_token"
     t.datetime "expires_at"
     t.boolean  "valid_token",     default: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.string   "email",                           null: false
     t.boolean  "authenticated",   default: false, null: false
     t.boolean  "primary",         default: false
@@ -728,8 +761,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "last_name"
     t.string   "email"
     t.boolean  "authenticated", default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.boolean  "primary",       default: false
     t.boolean  "downloading",   default: false, null: false
     t.datetime "last_download"
@@ -744,8 +777,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "token"
     t.string   "secret"
     t.datetime "token_expires_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.boolean  "valid_token",      default: false
     t.string   "first_name"
     t.string   "last_name"
@@ -763,8 +796,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.integer  "organization_id"
     t.string   "username"
     t.string   "password"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.string   "remote_id"
     t.boolean  "authenticated",     default: false, null: false
     t.boolean  "valid_credentials", default: false, null: false
@@ -774,7 +807,7 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.datetime "locked_at"
   end
 
-  add_index "person_organization_accounts", ["person_id", "organization_id"], name: "user_id_and_organization_id", unique: true, using: :btree
+  add_index "person_organization_accounts", ["person_id", "organization_id"], name: "index_organization_accounts_on_user_id_and_organization_id", unique: true, using: :btree
 
   create_table "person_relay_accounts", force: true do |t|
     t.integer  "person_id"
@@ -786,8 +819,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "employee_id"
     t.string   "username"
     t.boolean  "authenticated", default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.boolean  "primary",       default: false
     t.boolean  "downloading",   default: false, null: false
     t.datetime "last_download"
@@ -802,8 +835,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "screen_name"
     t.string   "token"
     t.string   "secret"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
     t.boolean  "valid_token",             default: false
     t.boolean  "authenticated",           default: false, null: false
     t.boolean  "primary",                 default: false
@@ -830,8 +863,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "country_code"
     t.string   "location"
     t.boolean  "primary",      default: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.string   "remote_id"
     t.boolean  "historic",     default: false
   end
@@ -844,8 +877,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "picture_of_type"
     t.string   "image"
     t.boolean  "primary",         default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
   end
 
   add_index "pictures", ["picture_of_id", "picture_of_type"], name: "picture_of", using: :btree
@@ -854,8 +887,8 @@ ActiveRecord::Schema.define(version: 20150123123429) do
     t.string   "token"
     t.string   "secret"
     t.boolean  "valid_token",     default: true
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.integer  "account_list_id"
     t.string   "oauth2_token"
   end
@@ -893,7 +926,7 @@ ActiveRecord::Schema.define(version: 20150123123429) do
   end
 
   add_index "versions", ["item_type", "event", "related_object_type", "related_object_id", "created_at", "item_id"], name: "index_versions_on_item_type", using: :btree
+  add_index "versions", ["item_type", "item_id", "related_object_type", "related_object_id", "created_at"], name: "related_object_index", using: :btree
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
-  add_index "versions", ["item_type", "related_object_type", "related_object_id", "created_at"], name: "related_object_index", using: :btree
 
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -61,4 +61,30 @@ describe Address do
       expect(Address.normalize_country('Some non-Existent country')).to eq('Some non-Existent country')
     end
   end
+
+  context 'remote_id' do
+    before(:each) do
+      stub_request(:get, %r{https:\/\/api\.smartystreets\.com\/street-address})
+          .with(headers: { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip, deflate', 'Content-Type' => 'application/json', 'User-Agent' => 'Ruby' })
+          .to_return(status: 200, body: '[{"input_index":0,"candidate_index":0,"delivery_line_1":"12958 Fawns Dell Pl","last_line":"Fishers IN 46038-1026",'\
+          '"delivery_point_barcode":"460381026587","components":{"primary_number":"12958","street_name":"Fawns Dell","street_suffix":"Pl",'\
+          '"city_name":"Fishers","state_abbreviation":"IN","zipcode":"46038","plus4_code":"1026","delivery_point":"58","delivery_point_check_digit":"7"},'\
+          '"metadata":{"record_type":"S","county_fips":"18057","county_name":"Hamilton","carrier_route":"C013","congressional_district":"05",'\
+          '"rdi":"Residential","elot_sequence":"0006","elot_sort":"A","latitude":39.97531,"longitude":-86.02973,"precision":"Zip9"},'\
+          '"analysis":{"dpv_match_code":"Y","dpv_footnotes":"AABB","dpv_cmra":"N","dpv_vacant":"N","active":"Y"}}]')
+      @address = create(:address, remote_id: '1-QTp1E')
+      @address.city = 'Amery'
+    end
+
+    it 'keeps remote id if user_changed is not set' do
+      @address.save
+      expect(@address.remote_id).to eq('1-QTp1E')
+    end
+
+    it 'sets remote_id to nil if user_changed is set' do
+      @address.user_changed = true
+      @address.save
+      expect(@address.remote_id).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
This should fix address records' `remote_id` and `master_address_id` fields getting set to nil when they shouldn't be.

I added the `master_address_id` validation to `Address` in order to make sure that specs were working okay, but realistically, this should be a DB constraint so we get error emails about it instead of silent failures on the user side.  For this reason, this is a review-only PR.