### PR TITLE
Allow sync to prayer letters for contacts without people

### DIFF
--- a/app/models/prayer_letters_account.rb
+++ b/app/models/prayer_letters_account.rb
@@ -25,7 +25,6 @@ class PrayerLettersAccount < ActiveRecord::Base
                   contact.mailing_address.present? &&
                   contact.active? &&
                   contact.mailing_address.valid_mailing_address? &&
-                  contact.primary_person.present? &&
                   contact.envelope_greeting.present? &&
                   contact.name.present?
       params = {

--- a/spec/models/prayer_letters_account_spec.rb
+++ b/spec/models/prayer_letters_account_spec.rb
@@ -85,4 +85,23 @@ describe PrayerLettersAccount do
       pla.create_contact(contact)
     end
   end
+
+  context '#subscribe_contacts' do
+    it 'syncronizes a contact even if it has no people' do
+      contact = create(:contact, account_list: pla.account_list, send_newsletter: 'Both', prayer_letters_id: 1)
+      contact.addresses << create(:address)
+      expect(contact.people.count).to eq(0)
+
+      contacts_body = '{"contacts":[{"name":"John Doe","greeting":"","file_as":"Doe, John","contact_id":"1",'\
+        '"address":{"street":"123 Somewhere St","city":"Fremont","state":"CA","postal_code":"94539",'\
+        '"country":"United States"},"external_id":' + contact.id.to_s +  '}]}'
+
+      stub = stub_request(:put, 'https://www.prayerletters.com/api/v1/contacts')
+        .with(body: contacts_body, headers: { 'Authorization' => 'Bearer MyString' })
+
+      expect(pla).to receive(:import_list)
+      pla.subscribe_contacts
+      expect(stub).to have_been_requested
+    end
+  end
 end


### PR DESCRIPTION
I'm with Steve Simms at the Cru Hackathon and we were debugging an error in my prayer letters account. I had a church in our contacts list with no people listed under it, and the check for `contact.primary_person.present?` prevented it from being synced. Since we created the `envelope_greeting` field, all of the fields for the prayer letters sync are from `Contact` so we can safely allow contacts to be synced even if they don't have people.