### PR TITLE
Fix logic & stack overflow bug for merge if same master person

### DIFF
--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -278,6 +278,15 @@ describe Person do
       expect(MasterPerson.find_by_id(loser_master_person_id)).to be_nil
     end
 
+    it 'merges two people correctly if they have the same master person' do
+      loser.update(master_person: winner.master_person)
+      expect(loser.master_person).to_not be_nil
+      orig_winner_master_person_id = winner.master_person_id
+      expect { winner.merge(loser) }.to_not raise_error
+      expect(winner.master_person_id).to eq(orig_winner_master_person_id)
+      expect(winner.master_person).to_not be_nil
+    end
+
     it 'creates a Version with a related_object_id', versioning: true do
       p1 = create(:person)
       p2 = create(:person)


### PR DESCRIPTION
@jbirdjavi gets the credit for the hard work on this one.

He tracked down the stack overflow in the person/contact merge to this place (I was meaning to look into it but hadn't got there yet). Justin found that when I did the merge of master person sources I didn't correctly handle the case of merging two people with the same master person. I confirmed via my new spec that that was causing a stack overflow without the `unless other_master_person_id == master_person_id`.