### PR TITLE
Check new address/email/phone primary if no primary

### DIFF
--- a/app/assets/javascripts/contacts.js.coffee.erb
+++ b/app/assets/javascripts/contacts.js.coffee.erb
@@ -365,13 +365,24 @@ $ ->
         $('input[type=checkbox].primary', fieldset).prop('checked',false)
         $(this).prop('checked', true)
 
+    $(document).on 'click', '.add_field', ->
+      fieldset = $(this).closest('.fieldset')
+      if $('input[type=checkbox].primary:checked:visible', fieldset).length == 0
+        newly_added_recordset = $('div.rs:eq(-2)', fieldset)
+        $('input[type=checkbox].primary', $(newly_added_recordset)).prop('checked', true)
+
     historicDisable = (check, input_selector) ->
-      fieldset = $(check).closest(".rs")
-      if $(check).is(":checked")
-        $(input_selector, fieldset).attr "readonly", true
+      recordset = $(check).closest('.rs')
+      if $(check).is(':checked')
+        $(input_selector, recordset).attr('readonly', true)
+        $(input_selector, recordset).addClass('no_longer_valid')
+        $('input[type=checkbox].primary', recordset).prop('checked', false)
+        $('input[type=checkbox].primary', recordset).attr('disabled', true)
       else
-        $(input_selector, fieldset).removeAttr "readonly"
-      return
+        $(input_selector, recordset).removeClass 'no_longer_valid'
+        $('input[type=checkbox].primary', recordset).removeAttr('disabled')
+        if recordset.children('.address_remotely_managed').length == 0
+          $(input_selector, recordset).removeAttr('readonly')
 
     $("input.address_historic").each ->
       historicDisable this, "input[type=text], textarea, .country_select"

--- a/app/assets/stylesheets/elements.css.scss
+++ b/app/assets/stylesheets/elements.css.scss
@@ -167,7 +167,7 @@ $leftmenuwidth: 200px;
 .green_darkest { color: $green_darkest; }
 .red { color: $error_red }
 
-input:read-only{
+input:read-only, textarea:read-only {
   background-color: #d3d3d3;
 }
 
@@ -194,3 +194,5 @@ input:read-only{
   height: 310px;
   overflow-y: auto;
 }
+
+.no_longer_valid { text-decoration:line-through }

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -116,7 +116,7 @@
 
         <div class="fieldset">
           <label class="fieldset_label"><%= _('Address') %></label>
-          <% contact.addresses.build if contact.addresses.blank? %>
+          <% contact.addresses.build(primary_mailing_address: true) if contact.addresses.blank? %>
           <%= f.fields_for :addresses do |builder| %>
             <%= render 'address_fields', builder: builder, object: contact %>
           <% end %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -100,7 +100,7 @@
       <%= builder.fields_for :email_addresses do |builder| %>
         <%= render 'people/email_address_fields', builder: builder, object: person %>
       <% end %>
-      <div class="sfield field_indent" data-behavior="add-wrapper">
+      <div class="sfield field_indent rs" data-behavior="add-wrapper">
         <%= link_to_add_fields(_('Add Email Address'), builder, :email_addresses, partial: 'people/email_address_fields') %>
       </div>
 
@@ -114,7 +114,7 @@
       <%= builder.fields_for :phone_numbers do |pf| %>
         <%= render 'people/phone_number_fields', builder: pf, object: person %>
       <% end %>
-      <div class="sfield field_indent" data-behavior="add-wrapper">
+      <div class="sfield field_indent rs" data-behavior="add-wrapper">
         <%= link_to_add_fields(_('Add Phone Number'), builder, :phone_numbers, partial: 'people/phone_number_fields') %>
       </div>
 
@@ -139,7 +139,7 @@
       <%= builder.fields_for :websites do |pf| %>
           <%= render 'people/website_fields', builder: pf, object: person %>
       <% end %>
-      <div class="sfield field_indent" data-behavior="add-wrapper">
+      <div class="sfield field_indent rs" data-behavior="add-wrapper">
         <%= link_to_add_fields(_('Add Website/Blog'), builder, :websites, partial: 'people/website_fields') %>
       </div>
     </div>


### PR DESCRIPTION
This also unchecks primary when you mark an item as no longer valid and uses a strike through format for no longer valid items.