### PR TITLE
Validate single primary address when user changed

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -43,7 +43,7 @@ class Contact < ActiveRecord::Base
 
   PERMITTED_ATTRIBUTES = [
     :name, :pledge_amount, :status, :notes, :full_name, :greeting, :envelope_greeting, :website, :pledge_frequency,
-    :pledge_start_date, :next_ask, :never_ask, :likely_to_give, :church_name, :send_newsletter,
+    :pledge_start_date, :next_ask, :never_ask, :likely_to_give, :church_name, :send_newsletter, :user_changed,
     :direct_deposit, :magazine, :pledge_received, :not_duplicated_with, :tag_list, :primary_person_id, :timezone,
     {
       contact_referrals_to_me_attributes: [:referred_by_id, :_destroy, :id],
@@ -64,6 +64,7 @@ class Contact < ActiveRecord::Base
   ]
 
   validates :name, presence: true
+  validates :addresses, single_primary: { primary_field: :primary_mailing_address }, if: :user_changed
 
   accepts_nested_attributes_for :people, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :donor_accounts, reject_if: :all_blank, allow_destroy: true
@@ -73,6 +74,8 @@ class Contact < ActiveRecord::Base
   before_save :set_notes_saved_at
   after_commit :sync_with_mail_chimp, :sync_with_prayer_letters, :sync_with_google_contacts
   before_destroy :delete_from_prayer_letters, :delete_people
+
+  attr_accessor :user_changed
 
   assignable_values_for :status, allow_blank: true do
     # Don't change these willy-nilly, they break the mobile app

--- a/app/validators/single_primary_validator.rb
+++ b/app/validators/single_primary_validator.rb
@@ -1,0 +1,31 @@
+class SinglePrimaryValidator < ActiveModel::EachValidator
+  attr_reader :record, :attribute, :value
+
+  def initialize(options)
+    options[:primary_field] ||= :primary
+    options[:message] ||= 'must have one and only one set as valid and primary'
+    super
+  end
+
+  def validate_each(record, attribute, value)
+    @record, @attribute, @value = record, attribute, value
+
+    add_error unless valid?
+  end
+
+  private
+
+  def valid?
+    return false if value.select(&:historic).any?(&options[:primary_field])
+    non_historic = value.reject(&:historic)
+    non_historic.empty? || non_historic.count(&options[:primary_field]) == 1
+  end
+
+  def add_error
+    if message = options[:message]
+      record.errors[attribute] << message
+    else
+      record.errors.add(attribute, :invalid)
+    end
+  end
+end

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -27,6 +27,8 @@
           <%= _('Basic Information') %>
         </div>
 
+        <%= f.hidden_field :user_changed, value: true %>
+
         <div class="field">
           <%= f.label :name, _('Name') %>
           <%= f.text_field :name, {placeholder: _('Last Name, First Name')} %>

--- a/spec/validators/single_primary_validator_spec.rb
+++ b/spec/validators/single_primary_validator_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe SinglePrimaryValidator do
+  let(:email_validator) { SinglePrimaryValidator.new(attributes: [:email_addresses]) }
+  let(:addresses_validator) do
+    SinglePrimaryValidator.new(attributes: [:addresses], primary_field: :primary_mailing_address)
+  end
+
+  it 'adds an error unless record has single primary non-historic address' do
+    {
+      [{ historic: false, primary_mailing_address: true }] => true,
+      [] => true,
+      [{ historic: true, primary_mailing_address: false }] => true,
+      [{ historic: true, primary_mailing_address: true },
+       { historic: true, primary_mailing_address: true }] => false,
+      [{ historic: false, primary_mailing_address: true },
+       { historic: false, primary_mailing_address: true }] => false,
+      [{ historic: true, primary_mailing_address: true }] => false,
+      [{ historic: nil, primary_mailing_address: true },
+       { historic: nil, primary_mailing_address: true }] => false,
+      [{ historic: nil, primary_mailing_address: false },
+       { historic: nil, primary_mailing_address: false }] => false,
+      [{ historic: false, primary_mailing_address: false }] => false
+    }.each do |address_attrs, valid|
+      contact = build(:contact, addresses: address_attrs.map { |attrs| build(:address, attrs) })
+      addresses_validator.validate(contact)
+      expect(contact.errors.empty?).to eq(valid)
+    end
+  end
+
+  it 'correctly uses :primary as the default primary_field' do
+    {
+      [{ historic: false, primary: true }] => true,
+      [{ historic: false, primary: false }] => false
+    }.each do |email_attrs, valid|
+      person = build(:person, email_addresses: email_attrs.map { |attrs| build(:email_address, attrs) })
+      email_validator.validate(person)
+      expect(person.errors.empty?).to eq(valid)
+    end
+  end
+end


### PR DESCRIPTION
This validates addresses to have at most one marked as primary and to have one marked as primary if there is at least one non-historic address. The `SinglePrimaryValidator` is designed to be able to work with emails and phones as well, but I had trouble getting the validation to work with the form so just left it for addresses only at this point. In order to prevent errors from occurring in imports, integrations, etc. if there is leftover invalid data, the validation is only applied if `user_changed` is true (taking the idea from Justin for that).