### PR TITLE
Set address as primary for added referrals

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -219,7 +219,9 @@ class ContactsController < ApplicationController
             end
 
             # create address
-            contact.addresses_attributes = [attributes.slice(:street, :city, :state, :postal_code)]
+            contact.addresses_attributes = [
+              attributes.slice(:street, :city, :state, :postal_code).merge(primary_mailing_address: true)
+            ]
 
             contact.save
 

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -175,5 +175,15 @@ describe ContactsController do
         expect(assigns(:people_sets)).to eq(people_sets)
       end
     end
+
+    describe '#save_referrals' do
+      it 'sets the address as primary for the created contact' do
+        expect {
+          xhr :post, :save_referrals, id: contact.id,
+              account_list: { contacts_attributes: { nil => { first_name: 'John', street: '1 Way' } } }
+        }.to change(Address, :count).from(0).to(1)
+        expect(Address.first.primary_mailing_address).to be_true
+      end
+    end
   end
 end


### PR DESCRIPTION
Since our box only allows you to add at most one address, it makes sense to mark it as primary.