### PR TITLE
Primary validation fix for addresses marked for destruction

### DIFF
--- a/app/assets/stylesheets/elements.css.scss
+++ b/app/assets/stylesheets/elements.css.scss
@@ -196,3 +196,4 @@ input:read-only, textarea:read-only {
 }
 
 .no_longer_valid { text-decoration:line-through }
+.marked_for_destruction { display: none; }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,8 @@ module ApplicationHelper
   end
 
   def link_to_remove_fields(f, hidden = false)
-    f.hidden_field(:_destroy) + link_to(_('Remove'), 'javascript:void(0)', class: 'ico ico_trash', style: hidden ? 'display:none' : '', data: { behavior: 'remove_field' })
+    f.hidden_field(:_destroy, value: f.object.marked_for_destruction? ? '1' : '') +
+      link_to(_('Remove'), 'javascript:void(0)', class: 'ico ico_trash', style: hidden ? 'display:none' : '', data: { behavior: 'remove_field' })
   end
 
   def link_to_add_fields(name, f, association, options = {})

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -37,7 +37,7 @@ class Address < ActiveRecord::Base
   end
 
   def destroy
-    update_attributes(deleted: true)
+    update_attributes(deleted: true, primary_mailing_address: false)
   end
 
   def not_blank?

--- a/app/validators/single_primary_validator.rb
+++ b/app/validators/single_primary_validator.rb
@@ -16,8 +16,9 @@ class SinglePrimaryValidator < ActiveModel::EachValidator
   private
 
   def valid?
-    return false if value.select(&:historic).any?(&options[:primary_field])
-    non_historic = value.reject(&:historic)
+    not_deleted = value.reject(&:marked_for_destruction?)
+    return false if not_deleted.select(&:historic).any?(&options[:primary_field])
+    non_historic = not_deleted.reject(&:historic)
     non_historic.empty? || non_historic.count(&options[:primary_field]) == 1
   end
 

--- a/app/views/contacts/_address_fields.html.erb
+++ b/app/views/contacts/_address_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="sfield address_field" data-behavior="field-wrapper">
+<div class="sfield address_field<%= ' marked_for_destruction' if builder.object.marked_for_destruction? %>" data-behavior="field-wrapper">
   <%= builder.hidden_field :user_changed, value: true %>
   <div class="ls">
     <%= builder.label :location %>

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -34,6 +34,14 @@ describe Address do
     end
   end
 
+  context '#destroy' do
+    it 'clears the primary mailing address flag when destroyed' do
+      address1 = create(:address, primary_mailing_address: true)
+      address1.destroy
+      expect(address1.primary_mailing_address).to be_false
+    end
+  end
+
   context '#country=' do
     it 'normalizes the country when assigned' do
       address = build(:address)

--- a/spec/validators/single_primary_validator_spec.rb
+++ b/spec/validators/single_primary_validator_spec.rb
@@ -20,9 +20,16 @@ describe SinglePrimaryValidator do
        { historic: nil, primary_mailing_address: true }] => false,
       [{ historic: nil, primary_mailing_address: false },
        { historic: nil, primary_mailing_address: false }] => false,
-      [{ historic: false, primary_mailing_address: false }] => false
+      [{ historic: false, primary_mailing_address: false }] => false,
+      [{ historic: nil, primary_mailing_address: false, mark_for_destruction: true }] => true
     }.each do |address_attrs, valid|
-      contact = build(:contact, addresses: address_attrs.map { |attrs| build(:address, attrs) })
+      contact = build(:contact)
+      contact.addresses = address_attrs.map do |attrs|
+        mark_for_destruction = attrs.delete(:mark_for_destruction)
+        address = build(:address, attrs)
+        address.mark_for_destruction if mark_for_destruction
+        address
+      end
       addresses_validator.validate(contact)
       expect(contact.errors.empty?).to eq(valid)
     end


### PR DESCRIPTION
Spencer caught a bug with the address primary validation logic where it wouldn't let you delete an address that was marked as primary. I also noticed that if you did delete an address marked as primary and then had another validation issue (e.g. a second address wasn't marked as primary), then that first address you clicked delete on would re-appear. This can be resolved by use of the rails `marked_for_destruction?` attribute which indicates that the user clicked delete for the item.