### PR TITLE
Fix error in merge loop if master person merged

### DIFF
--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -473,5 +473,16 @@ describe Contact do
         contact.merge_people
       }.to change(Person, :count).from(2).to(1)
     end
+
+    it 'does not error on second merge if their master person has been merged by first merge' do
+      person1 = create(:person)
+      person2 = create(:person)
+      person3 = create(:person, master_person: person2.master_person)
+      contact.people << person1
+      contact.people << person2
+      contact.people << person3
+
+      expect { contact.merge_people }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
We had an error in Errbit for a user whose Tnt import failed due to `NoMethodError: undefined method 'id' for nil:NilClass` on the line `other_master_person_id = other.master_person.id` in `person#merge`.

I believe what happened was that two of the people merged by the Tnt import (because they had the same donor number in Tnt) had the same master person and so the merge had changed their master person in the database but not in memory. I replicated the behavior with a spec and added `reload` to the beginning of the merge to prevent this.