### PR TITLE
Show address source and start date

### DIFF
--- a/app/exhibits/address_exhibit.rb
+++ b/app/exhibits/address_exhibit.rb
@@ -17,4 +17,15 @@ class AddressExhibit < DisplayCase::Exhibit
   def to_google
     [street, city, state, postal_code, country].select(&:present?).join(', ')
   end
+
+  def user_friendly_source
+    case source
+    when 'DataServer', 'Siebel' then 'Donor system'
+    when 'GoogleImport' then 'Google import'
+    when 'GoogleContactsSync'  then 'Google sync'
+    when 'TntImport'  then 'Tnt import'
+    when Address::MANUAL_SOURCE then  'Manual entry'
+    else source
+    end
+  end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -7,16 +7,21 @@ class Address < ActiveRecord::Base
 
   belongs_to :addressable, polymorphic: true, touch: true
   belongs_to :master_address
+  belongs_to :source_donor_account, class_name: 'DonorAccount'
 
   scope :current, -> { where(deleted: false) }
 
   before_validation :determine_master_address
+  before_save :set_manual_source_if_user_changed
   after_destroy :clean_up_master_address
   after_save :update_contact_timezone
 
   alias_method :destroy!, :destroy
 
   attr_accessor :user_changed
+
+  # Indicates an address was manually created/updated. Otherwise source is usually the import class name.
+  MANUAL_SOURCE = 'manual'
 
   assignable_values_for :location, allow_blank: true do
     [_('Home'), _('Business'), _('Mailing'), _('Other')]
@@ -49,6 +54,9 @@ class Address < ActiveRecord::Base
     self.seasonal = (seasonal? || other_address.seasonal?)
     self.location = other_address.location if location.blank?
     self.remote_id = other_address.remote_id if remote_id.blank?
+    self.source_donor_account = other_address.source_donor_account if source_donor_account.blank?
+    self.start_date = [start_date, other_address.start_date].compact.min
+    self.source = remote_id.present? ? 'Siebel' : [source, other_address.source].compact.first
     save(validate: false)
     other_address.destroy!
   end
@@ -103,6 +111,13 @@ class Address < ActiveRecord::Base
   end
 
   private
+
+  def set_manual_source_if_user_changed
+    return unless user_changed && (new_record? || (changed & %w(street city state country postal_code)).present?)
+    self.source = MANUAL_SOURCE
+    self.start_date = Date.today
+    self.source_donor_account = nil
+  end
 
   def determine_master_address
     if id.blank?

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -168,6 +168,7 @@ class Contact < ActiveRecord::Base
   def self.create_from_donor_account(donor_account, account_list)
     contact = account_list.contacts.new(name: donor_account.name)
     contact.addresses_attributes = donor_account.addresses_attributes
+    contact.addresses.each { |a| a.source_donor_account = donor_account }
     contact.save!
     contact.donor_accounts << donor_account
     contact

--- a/app/models/data_server.rb
+++ b/app/models/data_server.rb
@@ -360,7 +360,10 @@ class DataServer
           city: line['CITY'],
           state: line['STATE'],
           postal_code: line['ZIP'],
-          country: line['CNTRY_DESCR']
+          country: line['CNTRY_DESCR'],
+          source: 'DataServer',
+          start_date: parse_date(line['ADDR_CHANGED']),
+          primary_mailing_address: donor_account.addresses.find_by_primary_mailing_address(true).blank?
         }]
       end
       donor_account.save!
@@ -411,6 +414,17 @@ class DataServer
     proc { |exception, _handler, _attempts, _retries, _times|
       @org.update_attributes(url => exception.message)
     }
+  end
+
+  # Data server supports two date formats, try both of those
+  def parse_date(date_str)
+    return if date_str.blank?
+    Date.strptime(date_str, '%m/%d/%Y')
+  rescue ArgumentError
+    begin
+      Date.strptime(date_str, '%Y-%m-%d')
+    rescue ArgumentError
+    end
   end
 end
 

--- a/app/models/donor_account.rb
+++ b/app/models/donor_account.rb
@@ -84,6 +84,7 @@ class DonorAccount < ActiveRecord::Base
   end
 
   def addresses_attributes
-    Hash[addresses.collect.with_index { |address, i| [i, address.attributes.slice(*%w(street city state country postal_code))] }]
+    attrs = %w(street city state country postal_code start_date primary_mailing_address source source_donor_account_id)
+    Hash[addresses.collect.with_index { |address, i| [i, address.attributes.slice(*attrs)] }]
   end
 end

--- a/app/models/google_import.rb
+++ b/app/models/google_import.rb
@@ -110,7 +110,8 @@ class GoogleImport
       postal_code: google_address[:postcode],
       country: format_g_contact_country(google_address[:country]),
       location: google_address_rel_to_location(google_address[:rel]),
-      primary_mailing_address: google_address[:primary] }
+      primary_mailing_address: google_address[:primary],
+      source: 'GoogleImport' }
   end
 
   def format_g_contact_country(country)

--- a/app/models/siebel.rb
+++ b/app/models/siebel.rb
@@ -215,10 +215,10 @@ class Siebel < DataServer
         donor.addresses.each do |address|
           next if date_from.present? && DateTime.parse(address.updated_at) < date_from && contact.addresses.present?
 
-          add_or_update_address(address, donor_account)
+          add_or_update_address(address, donor_account, donor_account)
 
           # Make sure the contact has the primary address
-          add_or_update_address(address, contact) if address.primary == true
+          add_or_update_address(address, contact, donor_account) if address.primary == true
         end
       end
 
@@ -311,7 +311,7 @@ class Siebel < DataServer
     [person, contact_person]
   end
 
-  def add_or_update_address(address, object)
+  def add_or_update_address(address, object, source_donor_account)
     new_address = Address.new(street: [address.address1, address.address2, address.address3, address.address4].compact.join("\n"),
                               city: address.city,
                               state: address.state,
@@ -319,7 +319,10 @@ class Siebel < DataServer
                               primary_mailing_address: address.primary,
                               seasonal: address.seasonal,
                               location: address.type,
-                              remote_id: address.id)
+                              remote_id: address.id,
+                              source: 'Siebel',
+                              start_date: parse_date(address.updated_at),
+                              source_donor_account: source_donor_account)
 
     # If we can match it to an existing address, update that address
     object.addresses_including_deleted.each do |a|

--- a/app/models/tnt_import.rb
+++ b/app/models/tnt_import.rb
@@ -469,7 +469,8 @@ class TntImport
         end
       end
       addresses << {  street: street,  city: city,  state: state,  postal_code: postal_code,  country: country,
-        location: location,  region: row['Region'],  primary_mailing_address: primary_address  }
+        location: location,  region: row['Region'],  primary_mailing_address: primary_address,
+        source: 'TntImport'  }
     end
     addresses
   end

--- a/app/views/contacts/_address_fields.html.erb
+++ b/app/views/contacts/_address_fields.html.erb
@@ -20,6 +20,12 @@
     <%= builder.text_field :metro_area, placeholder: "Metro Area" %>
     <%= builder.label :country %>
     <%= builder.country_select :country, nil, {include_blank: true}, {class: 'country_select'} %><br/>
+
+    <div>
+      <%= builder.object.start_date ? _('Updated: ') + l(builder.object.start_date, format: :short) + '.' : '' %>
+      <%= builder.object.source ? _('Source: ') + _(exhibit(builder.object, self).user_friendly_source) : '' %>
+    </div>
+
     <div class="field_action">
         <%= builder.check_box :historic, class: 'address_historic' %>
         <%= builder.label :historic, "Address no longer valid" %>

--- a/db/migrate/20150127011605_add_source_to_address.rb
+++ b/db/migrate/20150127011605_add_source_to_address.rb
@@ -1,0 +1,5 @@
+class AddSourceToAddress < ActiveRecord::Migration
+  def change
+    add_column :addresses, :source, :string
+  end
+end

--- a/db/migrate/20150212133202_add_source_donor_account_id_to_addresses.rb
+++ b/db/migrate/20150212133202_add_source_donor_account_id_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddSourceDonorAccountIdToAddresses < ActiveRecord::Migration
+  def change
+    add_column :addresses, :source_donor_account_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150130162239) do
+ActiveRecord::Schema.define(version: 20150212133202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -130,6 +130,8 @@ ActiveRecord::Schema.define(version: 20150130162239) do
     t.string   "region"
     t.string   "metro_area"
     t.boolean  "historic",                default: false
+    t.string   "source"
+    t.integer  "source_donor_account_id"
   end
 
   add_index "addresses", ["addressable_id"], name: "index_addresses_on_person_id", using: :btree

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -95,4 +95,87 @@ describe Address do
       expect(@address.remote_id).to eq(nil)
     end
   end
+
+  context '#merge' do
+    let(:a1) { create(:address, start_date: Date.new(2014, 1, 1)) }
+    let(:a2) { create(:address, start_date: Date.new(2014, 1, 2)) }
+
+    describe 'takes the min first start_date of the two addresses' do
+      it 'works with a1 winner' do
+        a1.merge(a2)
+        expect(a1.start_date).to eq(Date.new(2014, 1, 1))
+      end
+      it 'works with a2 winner' do
+        a2.merge(a1)
+        expect(a2.start_date).to eq(Date.new(2014, 1, 1))
+      end
+    end
+
+    it 'takes the non-nil start date if only one specified' do
+      a1.update(start_date: nil)
+      a1.merge(a2)
+      expect(a1.start_date).to eq(Date.new(2014, 1, 2))
+    end
+
+    it 'sets source to Siebel if remote_id specified' do
+      a2.remote_id = 'a'
+      a1.update(source: 'not-siebel')
+      a1.merge(a2)
+      expect(a1.source).to eq('Siebel')
+    end
+
+    it 'takes the non-nil source by default' do
+      a2.update(source: 'import')
+      a1.merge(a2)
+      expect(a1.source).to eq('import')
+    end
+
+    it 'taks the non-nil source_donor_account' do
+      donor_account = create(:donor_account)
+      a2.source_donor_account = donor_account
+      a1.merge(a2)
+      expect(a1.source_donor_account).to eq(donor_account)
+    end
+  end
+
+  describe 'start_date and manual source behavior' do
+    it 'sets source to manual and start_date to today for a new user changed address' do
+      address = build(:address, user_changed: true)
+      address.save
+      expect(address.start_date).to eq(Date.today)
+      expect(address.source).to eq(Address::MANUAL_SOURCE)
+    end
+
+    it 'does not update start_date for a user changed when only address meta data is updated' do
+      da = create(:donor_account)
+      start = Date.new(2014, 1, 15)
+      a = Address.create(start_date: start, source: 'import', source_donor_account: da)
+      a.update(seasonal: true, primary_mailing_address: true, remote_id: '5', master_address_id: 2,
+               location: 'Other', user_changed: true)
+      expect(a.start_date).to eq(start)
+      expect(a.source).to eq('import')
+      expect(a.source_donor_account).to eq(da)
+    end
+
+    it 'updates to today for a user changed address when place attributes change' do
+      da = create(:donor_account)
+      [:street, :city, :state, :postal_code, :country].each do |field|
+        a = Address.create(start_date: Date.new(2014, 1, 15), source: 'import', source_donor_account: da)
+        a.update(field => 'not-nil', user_changed: true)
+        expect(a.start_date).to eq(Date.today)
+        expect(a.source).to eq(Address::MANUAL_SOURCE)
+        expect(a.source_donor_account).to be_nil
+      end
+    end
+
+    it 'does not update start date or source for non-user changed address when place attributes change' do
+      start = Date.new(2014, 1, 15)
+      [:street, :city, :state, :postal_code, :country].each do |field|
+        a = Address.create(source: 'import', start_date: start)
+        a.update(field => 'a')
+        expect(a.start_date).to eq(start)
+        expect(a.source).to eq('import')
+      end
+    end
+  end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -132,6 +132,7 @@ describe Contact do
         @contact = Contact.create_from_donor_account(@donor_account, @account_list)
       }.to change(Address, :count)
       @contact.addresses.first.equal_to?(@donor_account.addresses.first).should be_true
+      expect(@contact.addresses.first.source_donor_account).to eq(@donor_account)
     end
 
   end

--- a/spec/models/tnt_import_spec.rb
+++ b/spec/models/tnt_import_spec.rb
@@ -95,9 +95,12 @@ describe TntImport do
           @address = create(:address, primary_mailing_address: true)
           contact.addresses << @address
           contact.save
+          expect(contact.addresses.where(primary_mailing_address: true).count).to eq(1)
+
           expect {
             import.send(:import_contacts)
           }.not_to change { contact.addresses.where(primary_mailing_address: true).count }
+
           expect { # make sure it survives a second import
             import.send(:import_contacts)
           }.not_to change { contact.addresses.where(primary_mailing_address: true).count }


### PR DESCRIPTION
Records and displays the address source and for those from the donor system or manually entered, the updated date (`source_date`) as well.
![image](https://cloud.githubusercontent.com/assets/2855507/6219189/4e94640a-b5f4-11e4-9c0b-f32016abdc0a.png)

This also tracks the `source_donor_account` for addresses which isn't displayed but is a prerequisite for some upcoming logic for which addresses get set as primary from the donor system (i.e. just set it if the current primary address is also from the donor system and from that same donor id). It made sense to add in the source donor account as part of this PR though since it conceptually fits in with the other source info.