### PR TITLE
New Siebel address primary only if current primary same donor

### DIFF
--- a/app/models/siebel.rb
+++ b/app/models/siebel.rb
@@ -312,11 +312,43 @@ class Siebel < DataServer
   end
 
   def add_or_update_address(address, object, source_donor_account)
+    new_address = new_address_from_siebel(address, object, source_donor_account)
+
+    place_match = object.addresses_including_deleted.find { |a| a.equal_to?(new_address) }
+    remote_id_match = object.addresses_including_deleted.find { |a| a.remote_id == new_address.remote_id }
+
+    address_to_update = place_match || remote_id_match
+
+    # If Siebel always generates a new remote id for changed addresses, this isn't really needed, but in case
+    # they sometimes use the same remote id for a new address, we should disconnecte the old address from the
+    # remote id and attach it to the manually added / imported address (place_match) that matches the Siebel one.
+    remote_id_match.update(remote_id: nil) if remote_id_match && place_match && place_match != remote_id_match
+
+    if address_to_update
+      address_to_update.update_attributes(new_address.attributes.select { |_k, v| v.present? })
+    else
+      object.addresses << new_address
+    end
+
+    begin
+      object.save!
+    rescue ActiveRecord::RecordInvalid => e
+      raise e.message + " - #{address.inspect}"
+    end
+  end
+
+  def new_address_from_siebel(address, object, source_donor_account)
+    current_primary = object.addresses.find_by(primary_mailing_address: true)
+    make_primary = current_primary.blank? || (address.primary && current_primary.source == 'Siebel' &&
+      source_donor_account.present? && current_primary.source_donor_account == source_donor_account)
+
+    object.addresses.each { |a| a.primary_mailing_address = false } if current_primary.present? && make_primary
+
     new_address = Address.new(street: [address.address1, address.address2, address.address3, address.address4].compact.join("\n"),
                               city: address.city,
                               state: address.state,
                               postal_code: address.zip,
-                              primary_mailing_address: address.primary,
+                              primary_mailing_address: make_primary,
                               seasonal: address.seasonal,
                               location: address.type,
                               remote_id: address.id,
@@ -324,20 +356,10 @@ class Siebel < DataServer
                               start_date: parse_date(address.updated_at),
                               source_donor_account: source_donor_account)
 
-    # If we can match it to an existing address, update that address
-    object.addresses_including_deleted.each do |a|
-      next unless a.remote_id == new_address.remote_id || a.equal_to?(new_address)
-      a.update_attributes(new_address.attributes.select { |_k, v| v.present? })
-      return a
-    end
+    # Set the master address so we can match by the same address formatted differently
+    new_address.find_or_create_master_address
 
-    # We didn't find a match. save it as a new address
-    object.addresses << new_address
-    begin
-      object.save!
-    rescue ActiveRecord::RecordInvalid => e
-      raise e.message + " - #{address.inspect}"
-    end
+    new_address
   end
 
   def add_or_update_phone_number(phone_number, person)


### PR DESCRIPTION
This will also re-attach the Siebel remote id to manually added addresses which have the same place as the Siebel address. That will make more sense when I do my next PR for the MPDX-244 address change ticket which will make Siebel addresses read only but provide an "email donor services" link that would pre-fill a Gmail template for the address change.

The case I have in mind is if when we have the Siebel address as read-only a user emails donor services to get it changed but then also wants an immediate change in MPDX say for their newsletter. So they create a new address that's correct. Then this takes care of the logic for the new Siebel address coming in getting correctly merged in with the potential for the manually created address being for the same place.