### PR TITLE
Read-only Siebel address but with email template link

### DIFF
--- a/app/assets/javascripts/contacts.js.coffee.erb
+++ b/app/assets/javascripts/contacts.js.coffee.erb
@@ -359,6 +359,11 @@ $ ->
 
     $('.country_select').selectToAutocomplete()
 
+    $('.address_remotely_managed').each ->
+      fieldset = $(this).closest('.rs')
+      $("input[type=text], textarea, .country_select", fieldset).attr 'readonly', true
+      $('.address_region, .address_metro_area', fieldset).removeAttr 'readonly'
+
     $(document).on 'click', 'input.primary', ->
       if $(this).prop('checked',true)
         fieldset = $(this).closest('.fieldset')

--- a/app/exhibits/address_exhibit.rb
+++ b/app/exhibits/address_exhibit.rb
@@ -28,4 +28,19 @@ class AddressExhibit < DisplayCase::Exhibit
     else source
     end
   end
+
+  def address_change_email_body
+    if source_donor_account.present?
+      donor_info = "\"#{source_donor_account.name}\" (donor ##{source_donor_account.account_number})"
+    else
+      donor_info = "\"#{addressable.name}\""
+    end
+
+    "Dear Donation Services,\n\n"\
+    "One of my donors, #{donor_info} has a new current address.\n\n"\
+    "Please update their address to:\n\n"\
+    "REPLACE WITH NEW STREET\n"\
+    "REPLACE WITH NEW CITY, STATE, ZIP\n\n"\
+    "Thanks!\n\n"
+  end
 end

--- a/app/helpers/gmail_compose_link_helper.rb
+++ b/app/helpers/gmail_compose_link_helper.rb
@@ -1,0 +1,16 @@
+module GmailComposeLinkHelper
+  def link_to_gmail_compose(name, opts = {})
+    gmail_opts = [:to, :subject, :body, :cc, :bcc]
+    link_to(name, gmail_compose_url(opts.slice(*gmail_opts)), opts.except(*gmail_opts))
+  end
+
+  private
+
+  # See: http://stackoverflow.com/questions/6548570/url-to-compose-a-message-in-gmail-with-full-gmail-interface-and-specified-to-b
+  def gmail_compose_url(opts = {})
+    "https://mail.google.com/mail/?#{
+    { view: 'cm', fs: 1, to: opts[:to], su: opts[:subject], body: opts[:body], bcc: opts[:bcc], cc: opts[:cc] }
+      .select { |_, v| v.present? }.to_param
+    }"
+  end
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -129,8 +129,6 @@ class Address < ActiveRecord::Base
 
   def update_or_create_master_address
     if (changed & %w(street city state country postal_code)).present?
-      self.remote_id = nil if user_changed
-
       new_master_address_match = find_master_address
 
       if master_address.nil? || master_address != new_master_address_match

--- a/app/models/donor_account.rb
+++ b/app/models/donor_account.rb
@@ -84,7 +84,7 @@ class DonorAccount < ActiveRecord::Base
   end
 
   def addresses_attributes
-    attrs = %w(street city state country postal_code start_date primary_mailing_address source source_donor_account_id)
+    attrs = %w(street city state country postal_code start_date primary_mailing_address source source_donor_account_id remote_id)
     Hash[addresses.collect.with_index { |address, i| [i, address.attributes.slice(*attrs)] }]
   end
 end

--- a/app/views/contacts/_address_fields.html.erb
+++ b/app/views/contacts/_address_fields.html.erb
@@ -7,10 +7,11 @@
   <div class="rs">
 
     <% if builder.object.remote_id.present? %>
-      <%= _('From donor system.') %>
-      <%= link_to_gmail_compose(_('Email donor services to change'), target: '_blank',
+      <%= _('From donor system. To make changes, ') %>
+      <%= link_to_gmail_compose(_('click here'), target: '_blank',
                                 to: 'Cru Donation Services <donation.services@cru.org>', subject: 'Donor address change',
                                 body: exhibit(builder.object, self).address_change_email_body + current_user.first_name.to_s) %>
+      <%= _(' to email donation services.') %>
       <input type="hidden" class="address_remotely_managed">
     <% end %>
 

--- a/app/views/contacts/_address_fields.html.erb
+++ b/app/views/contacts/_address_fields.html.erb
@@ -6,6 +6,14 @@
   </div>
   <div class="rs">
 
+    <% if builder.object.remote_id.present? %>
+      <%= _('From donor system.') %>
+      <%= link_to_gmail_compose(_('Email donor services to change'), target: '_blank',
+                                to: 'Cru Donation Services <donation.services@cru.org>', subject: 'Donor address change',
+                                body: exhibit(builder.object, self).address_change_email_body + current_user.first_name.to_s) %>
+      <input type="hidden" class="address_remotely_managed">
+    <% end %>
+
     <%= builder.label :street %>
     <%= builder.text_area :street, rows: 3, placeholder: "Street address" %>
     <%= builder.label :city %>
@@ -15,9 +23,9 @@
     <%= builder.label :postal_code %>
     <%= builder.text_field :postal_code, placeholder: "Postal Code" %>
     <%= builder.label :region %>
-    <%= builder.text_field :region, placeholder: "Region" %>
+    <%= builder.text_field :region, placeholder: "Region", class: 'address_region' %>
     <%= builder.label :metro_area %>
-    <%= builder.text_field :metro_area, placeholder: "Metro Area" %>
+    <%= builder.text_field :metro_area, placeholder: "Metro Area", class: 'address_metro_area' %>
     <%= builder.label :country %>
     <%= builder.country_select :country, nil, {include_blank: true}, {class: 'country_select'} %><br/>
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -70,32 +70,6 @@ describe Address do
     end
   end
 
-  context 'remote_id' do
-    before(:each) do
-      stub_request(:get, %r{https:\/\/api\.smartystreets\.com\/street-address})
-          .with(headers: { 'Accept' => 'application/json', 'Accept-Encoding' => 'gzip, deflate', 'Content-Type' => 'application/json', 'User-Agent' => 'Ruby' })
-          .to_return(status: 200, body: '[{"input_index":0,"candidate_index":0,"delivery_line_1":"12958 Fawns Dell Pl","last_line":"Fishers IN 46038-1026",'\
-          '"delivery_point_barcode":"460381026587","components":{"primary_number":"12958","street_name":"Fawns Dell","street_suffix":"Pl",'\
-          '"city_name":"Fishers","state_abbreviation":"IN","zipcode":"46038","plus4_code":"1026","delivery_point":"58","delivery_point_check_digit":"7"},'\
-          '"metadata":{"record_type":"S","county_fips":"18057","county_name":"Hamilton","carrier_route":"C013","congressional_district":"05",'\
-          '"rdi":"Residential","elot_sequence":"0006","elot_sort":"A","latitude":39.97531,"longitude":-86.02973,"precision":"Zip9"},'\
-          '"analysis":{"dpv_match_code":"Y","dpv_footnotes":"AABB","dpv_cmra":"N","dpv_vacant":"N","active":"Y"}}]')
-      @address = create(:address, remote_id: '1-QTp1E')
-      @address.city = 'Amery'
-    end
-
-    it 'keeps remote id if user_changed is not set' do
-      @address.save
-      expect(@address.remote_id).to eq('1-QTp1E')
-    end
-
-    it 'sets remote_id to nil if user_changed is set' do
-      @address.user_changed = true
-      @address.save
-      expect(@address.remote_id).to eq(nil)
-    end
-  end
-
   context '#merge' do
     let(:a1) { create(:address, start_date: Date.new(2014, 1, 1)) }
     let(:a2) { create(:address, start_date: Date.new(2014, 1, 2)) }

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -127,12 +127,13 @@ describe Contact do
     end
 
     it "should copy the donor account's addresses" do
-      create(:address, addressable: @donor_account)
+      create(:address, addressable: @donor_account, remote_id: '1')
       expect {
         @contact = Contact.create_from_donor_account(@donor_account, @account_list)
       }.to change(Address, :count)
       @contact.addresses.first.equal_to?(@donor_account.addresses.first).should be_true
       expect(@contact.addresses.first.source_donor_account).to eq(@donor_account)
+      expect(@contact.addresses.first.remote_id).to eq('1')
     end
 
   end


### PR DESCRIPTION
This will make Siebel addresses read only to the user (except for the primary, no longer valid, region and metro area fields) but it will include a link to compose an email to donor services and the email will have a filled in template like below. I also made one small change to copy over the `remote_id` from a donor account to contact when we generate a contact form a donor account.

![address](https://cloud.githubusercontent.com/assets/2855507/6259321/8bb10224-b79f-11e4-8b08-ffcf518a3db3.png)

![gmail_compose](https://cloud.githubusercontent.com/assets/2855507/6259364/ed5d0b8a-b79f-11e4-8832-69eb89a23c12.png)


