### PR TITLE
Fix import of appeal wo/ contacts, move dup check to model

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -27,8 +27,10 @@ class Appeal < ActiveRecord::Base
     bulk_add_contacts(contacts_by_opts(statuses, tags, excludes))
   end
 
-  def bulk_add_contacts(contacts)
-    AppealContact.import(contacts.uniq.map { |c| AppealContact.new(contact: c, appeal: self) })
+  def bulk_add_contacts(contacts_to_add)
+    appeal_contact_ids = contacts.pluck(:id).to_set
+    contacts_to_add = contacts_to_add.uniq.reject { |c| appeal_contact_ids.include?(c.id) }
+    AppealContact.import(contacts_to_add.map { |c| AppealContact.new(contact: c, appeal: self) })
   end
 
   def contacts_by_opts(statuses, tags, excludes)

--- a/app/models/tnt_import.rb
+++ b/app/models/tnt_import.rb
@@ -268,9 +268,7 @@ class TntImport
     appeals_by_tnt_id = find_or_create_appeals_by_tnt_id
 
     appeals_by_tnt_id.each do |appeal_tnt_id, appeal|
-      appeal_contact_ids = appeal.contacts.pluck(:id).to_set
-      contacts = contacts_by_tnt_appeal_id[appeal_tnt_id].reject { |c| appeal_contact_ids.include?(c.id) }
-      appeal.bulk_add_contacts(contacts)
+      appeal.bulk_add_contacts(contacts_by_tnt_appeal_id[appeal_tnt_id] || [])
     end
 
     import_appeal_amounts(appeals_by_tnt_id)

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -17,11 +17,15 @@ describe Appeal do
   end
 
   context '#bulk_add_contacts' do
-    it 'bulk adds the contacts but removes duplicates first' do
+    it 'bulk adds the contacts but removes duplicates first and does not create dups when run again' do
       contact2 = create(:contact)
       expect {
         appeal.bulk_add_contacts([contact, contact, contact2])
       }.to change(appeal.contacts, :count).from(0).to(2)
+
+      expect {
+        appeal.bulk_add_contacts([contact, contact, contact2])
+      }.to_not change(appeal.contacts, :count).from(2)
     end
   end
 

--- a/spec/models/tnt_import_spec.rb
+++ b/spec/models/tnt_import_spec.rb
@@ -650,6 +650,14 @@ describe TntImport do
       appeal.reload
       expect(appeal.contacts.count).to eq(1)
     end
+
+    it 'does not error if an appeal has no contacts' do
+      expect(import).to receive(:find_or_create_appeals_by_tnt_id).and_return(1 => create(:appeal))
+      contacts_by_tnt_appeal_id = {}
+      expect { import.send(:import_appeals, contacts_by_tnt_appeal_id) }.to_not raise_error
+      expect(Appeal.count).to eq(1)
+      expect(AppealContact.count).to eq(0)
+    end
   end
 
   context '#import' do


### PR DESCRIPTION
I found an error in the Tnt appeal import in a case when there are no contacts for the appeal when I was testing a user's data for pledge mismatches.