### PR TITLE
Make AppealContact unique

### DIFF
--- a/db/migrate/20150226131119_make_appeal_contacts_unique.rb
+++ b/db/migrate/20150226131119_make_appeal_contacts_unique.rb
@@ -1,0 +1,17 @@
+class MakeAppealContactsUnique < ActiveRecord::Migration
+  def change
+    Appeal.find_each do |appeal|
+      contact_ids_so_far = Set.new
+      appeal.appeal_contacts.each do |appeal_contact|
+        if contact_ids_so_far.include?(appeal_contact.contact_id)
+          appeal_contact.destroy
+        else
+          contact_ids_so_far << appeal_contact.contact_id
+        end
+      end
+    end
+
+    remove_index :appeal_contacts, [:appeal_id, :contact_id]
+    add_index :appeal_contacts, [:appeal_id, :contact_id], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150225181123) do
+ActiveRecord::Schema.define(version: 20150226131119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 20150225181123) do
     t.datetime "updated_at"
   end
 
-  add_index "appeal_contacts", ["appeal_id", "contact_id"], name: "index_appeal_contacts_on_appeal_id_and_contact_id", using: :btree
+  add_index "appeal_contacts", ["appeal_id", "contact_id"], name: "index_appeal_contacts_on_appeal_id_and_contact_id", unique: true, using: :btree
   add_index "appeal_contacts", ["appeal_id"], name: "index_appeal_contacts_on_appeal_id", using: :btree
   add_index "appeal_contacts", ["contact_id"], name: "index_appeal_contacts_on_contact_id", using: :btree
 


### PR DESCRIPTION
This modifies the index on `appeal_contacts` to be unique by contact and appeal. I don't know of any duplicates in the data at this point, but AngularJS has issues with duplicates and there's no point in having them. This is preventative for any future bugs that might introduce dups.