### PR TITLE
Increase donation fields precision

### DIFF
--- a/db/migrate/20150227181652_increase_donation_fields_precision.rb
+++ b/db/migrate/20150227181652_increase_donation_fields_precision.rb
@@ -1,0 +1,13 @@
+class IncreaseDonationFieldsPrecision < ActiveRecord::Migration
+  def change
+    change_column :appeals, :amount, :decimal, precision: 11, scale: 2
+    change_column :contacts, :pledge_amount, :decimal, precision: 11, scale: 2
+    change_column :contacts, :total_donations, :decimal, precision: 13, scale: 2
+    change_column :designation_accounts, :balance, :decimal, precision: 11, scale: 2
+    change_column :designation_profiles, :balance, :decimal, precision: 11, scale: 2
+    change_column :donations, :tendered_amount, :decimal, precision: 11, scale: 2
+    change_column :donations, :amount, :decimal, precision: 11, scale: 2
+    change_column :donations, :appeal_amount, :decimal, precision: 11, scale: 2
+    change_column :donor_accounts, :total_donations, :decimal, precision: 13, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150226131119) do
+ActiveRecord::Schema.define(version: 20150227181652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,7 +138,7 @@ ActiveRecord::Schema.define(version: 20150226131119) do
   create_table "appeals", force: true do |t|
     t.string   "name"
     t.integer  "account_list_id"
-    t.decimal  "amount",          precision: 8, scale: 2
+    t.decimal  "amount",          precision: 11, scale: 2
     t.text     "description"
     t.date     "end_date"
     t.datetime "created_at"
@@ -221,9 +221,9 @@ ActiveRecord::Schema.define(version: 20150226131119) do
     t.integer  "account_list_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.decimal  "pledge_amount",                        precision: 8,  scale: 2
+    t.decimal  "pledge_amount",                        precision: 11, scale: 2
     t.string   "status"
-    t.decimal  "total_donations",                      precision: 10, scale: 2
+    t.decimal  "total_donations",                      precision: 13, scale: 2
     t.date     "last_donation_date"
     t.date     "first_donation_date"
     t.text     "notes"
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 20150226131119) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "organization_id"
-    t.decimal  "balance",            precision: 8, scale: 2
+    t.decimal  "balance",            precision: 11, scale: 2
     t.datetime "balance_updated_at"
     t.string   "name"
     t.string   "staff_account_id"
@@ -285,13 +285,13 @@ ActiveRecord::Schema.define(version: 20150226131119) do
 
   create_table "designation_profiles", force: true do |t|
     t.string   "remote_id"
-    t.integer  "user_id",                                    null: false
-    t.integer  "organization_id",                            null: false
+    t.integer  "user_id",                                     null: false
+    t.integer  "organization_id",                             null: false
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "code"
-    t.decimal  "balance",            precision: 8, scale: 2
+    t.decimal  "balance",            precision: 11, scale: 2
     t.datetime "balance_updated_at"
     t.integer  "account_list_id"
   end
@@ -307,9 +307,9 @@ ActiveRecord::Schema.define(version: 20150226131119) do
     t.string   "motivation"
     t.string   "payment_method"
     t.string   "tendered_currency"
-    t.decimal  "tendered_amount",        precision: 8, scale: 2
+    t.decimal  "tendered_amount",        precision: 11, scale: 2
     t.string   "currency"
-    t.decimal  "amount",                 precision: 8, scale: 2
+    t.decimal  "amount",                 precision: 11, scale: 2
     t.text     "memo"
     t.date     "donation_date"
     t.datetime "created_at"
@@ -317,7 +317,7 @@ ActiveRecord::Schema.define(version: 20150226131119) do
     t.string   "payment_type"
     t.string   "channel"
     t.integer  "appeal_id"
-    t.decimal  "appeal_amount",          precision: 8, scale: 2
+    t.decimal  "appeal_amount",          precision: 11, scale: 2
   end
 
   add_index "donations", ["appeal_id"], name: "index_donations_on_appeal_id", using: :btree
@@ -342,7 +342,7 @@ ActiveRecord::Schema.define(version: 20150226131119) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "master_company_id"
-    t.decimal  "total_donations",                precision: 10, scale: 2
+    t.decimal  "total_donations",                precision: 13, scale: 2
     t.date     "last_donation_date"
     t.date     "first_donation_date"
     t.string   "donor_type",          limit: 20


### PR DESCRIPTION
While running the Siebel import for all users with info going back 10 years to pull in the address source info, I ran into the error below. It seems that one of the accounts (maybe a ministry account) got a donation of $1 million or more at one point. This increases the precision of the donation related fields by 3 to handle larger gifts. If one of our ministries gets a $1 billion gift some time, we can always bump this up again :), but these numbers should suffice for the ministry and personal gift levels for our orgs.

```
PG::Error: ERROR:  numeric field overflow
DETAIL:  A field with precision 8, scale 2 must round to an absolute value less than 10^6.
: INSERT INTO "donations" ("amount", "channel", "created_at", "currency", "designation_account_id", "donation_date", "donor_account_id", "motivation", "payment_method", "remote_id", "tendered_amount", "tendered_currency", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING "id"
```