### PR TITLE
Retry Google sync errors via Sidekiq not Retryable

### DIFF
--- a/app/workers/lower_retry_worker.rb
+++ b/app/workers/lower_retry_worker.rb
@@ -18,4 +18,7 @@ class LowerRetryWorker
       send(method, *args)
     end
   end
+
+  class RetryJobButNoAirbrakeError < StandardError
+  end
 end

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -3,7 +3,10 @@ Airbrake.configure do |config|
   config.host = 'errors.uscm.org'
   config.port = 443
   config.secure = config.port == 443
-  config.ignore_only = config.ignore + ['Google::APIClient::ServerError', 'Net::IMAP::BadResponseError']
+  config.ignore_only = config.ignore + [
+    'Google::APIClient::ServerError', 'Net::IMAP::BadResponseError',
+    'LowerRetryWorker::RetryJobButNoAirbrakeError'
+  ]
 end
 
 module Airbrake

--- a/lib/google_contacts_cache.rb
+++ b/lib/google_contacts_cache.rb
@@ -4,7 +4,9 @@ class GoogleContactsCache
   end
 
   def cache_all_g_contacts
-    cache_g_contacts(@account.contacts_api_user.contacts(showdeleted: false), true)
+    GoogleContactsIntegrator.retry_on_api_errs do
+      cache_g_contacts(@account.contacts_api_user.contacts(showdeleted: false), true)
+    end
   end
 
   def cache_g_contacts(g_contacts, all_cached = false)
@@ -28,7 +30,7 @@ class GoogleContactsCache
     cached_g_contact = @g_contact_by_id[remote_id]
     return cached_g_contact if cached_g_contact
     return nil if @all_g_contacts_cached
-    g_contact = GoogleContactsIntegrator.retryable_exp_backoff do
+    g_contact = GoogleContactsIntegrator.retry_on_api_errs do
       @account.contacts_api_user.get_contact(remote_id)
     end
     g_contact unless g_contact.deleted?
@@ -50,7 +52,7 @@ class GoogleContactsCache
     elsif @all_g_contacts_cached
       []
     else
-      GoogleContactsIntegrator.retryable_exp_backoff do
+      GoogleContactsIntegrator.retry_on_api_errs do
         @account.contacts_api_user.query_contacts(name, showdeleted: false)
       end
     end


### PR DESCRIPTION
This improves the Google contacts sync error handling so when the Google API gives a temporary error (either a 500s error or 403 rate limit exceeded) the Google contacts sync job will get bumped to the retry queue with an exponential backoff as specified by the `LowerRetryWorker` but no errors will be reported to Airbrake for that. I previously used a 1 hour delay with `Retryable` but 1) that held up a Sidekiq thread for an hour and 2) I think it may have caused unauthorized errors due to the token expiring. The latter could be fixed separately, but this will hopefully fix them both at once.