### PR TITLE
Fix breaking appeals spec at end of month

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -97,8 +97,8 @@ class Appeal < ActiveRecord::Base
   # We define e.g. "stopped giving in the past 2 months" as no pledge set current, no gifts in the previous
   # 2 full months, and at least 3 gifts in the prior 10 months.
   def no_stopped_giving_recently(contacts, prev_full_months = 2, prior_months = 10, prior_num_gifts = 3)
-    prior_window_end = (Date.today.prev_month << prev_full_months).end_of_month
-    prior_window_start = (prior_window_end << prior_months).beginning_of_month
+    prior_window_end = Date.today << prev_full_months
+    prior_window_start = prior_window_end << prior_months
 
     former_givers_sql = "
       SELECT contacts.id

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -89,7 +89,8 @@ describe Appeal do
       donation.update(amount: 150)
       expect(appeal.contacts_by_opts([], ['tag'], specialGift3months: true).count).to eq(1)
 
-      donation2 = create(:donation, amount: 50, donation_date: 1.day.ago)
+      donation.update(donation_date: Date.today << 3)
+      donation2 = create(:donation, amount: 50, donation_date: Date.today)
       donor_account.donations << donation2
       contact.update_donation_totals(donation2)
       expect(appeal.contacts_by_opts([], ['tag'], specialGift3months: true).count).to eq(1)

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -78,13 +78,10 @@ describe Appeal do
     end
 
     it 'excludes special givers in the 3 months if specified' do
-      today = Date.new(2015, 2, 2)
-      expect(Date).to receive(:today).at_least(:once).and_return(today)
-
       contact.tag_list = ['tag']
       contact.save
       contact.update(pledge_amount: 50, pledge_frequency: 1, status: 'Partner - Pray')
-      donation.update(amount: 500, donation_date: Date.new(2014, 11, 1))
+      donation.update(amount: 500, donation_date: 2.months.ago)
 
       expect(appeal.contacts_by_opts([], ['tag'], {}).count).to eq(1)
       expect(appeal.contacts_by_opts([], ['tag'], specialGift3months: true).count).to eq(0)
@@ -92,7 +89,7 @@ describe Appeal do
       donation.update(amount: 150)
       expect(appeal.contacts_by_opts([], ['tag'], specialGift3months: true).count).to eq(1)
 
-      donation2 = create(:donation, amount: 50, donation_date: Date.new(2015, 2, 1))
+      donation2 = create(:donation, amount: 50, donation_date: 1.day.ago)
       donor_account.donations << donation2
       contact.update_donation_totals(donation2)
       expect(appeal.contacts_by_opts([], ['tag'], specialGift3months: true).count).to eq(1)
@@ -102,6 +99,7 @@ describe Appeal do
     end
 
     it 'excludes contacts who stopped giving in the past 2 months if specified' do
+
       expect(appeal.contacts_by_opts(['Partner - Financial'], [], stoppedGiving2months: true).count).to eq(1)
       expect(appeal.contacts_by_opts(['Partner - Financial'], [], stoppedGiving2months: true).count).to eq(1)
 
@@ -109,6 +107,7 @@ describe Appeal do
       expect(appeal.contacts_by_opts(['Partner - Financial'], [], stoppedGiving2months: true).count).to eq(1)
 
       contact.update(pledge_amount: 0, last_donation_date: 3.months.ago)
+
       expect(appeal.contacts_by_opts(['Partner - Financial'], [], stoppedGiving2months: true).count).to eq(1)
 
       donor_account.donations << create(:donation, amount: 25, donation_date: 4.months.ago)
@@ -146,7 +145,7 @@ describe Appeal do
         contact.update(pledge_frequency: giving_info[:pledge_frequency], last_donation_date: nil)
         giving_info[:amounts].reverse.each_with_index do |amount, i|
           next if amount == 0
-          d = create(:donation, donor_account: donor_account, amount: amount, donation_date: i.months.ago)
+          d = create(:donation, donor_account: donor_account, amount: amount, donation_date: Date.today << i)
           contact.update_donation_totals(d)
         end
 


### PR DESCRIPTION
The build broke today for a reason seemingly unrelated to my change and after investigating the two failing `Appeal` specs, my suspicion is that it had to do with it being the last few hours of the month EST (first few hours UTC) and that the `Date.today` and `0.months.ago` values were slightly different. I fixed the specs and also simplified the logic for the `no_stopped_giving_recently` method to just check for gifts from two months ago today.