### PR TITLE
Siebel has a Seasonal address type

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -24,7 +24,7 @@ class Address < ActiveRecord::Base
   MANUAL_SOURCE = 'manual'
 
   assignable_values_for :location, allow_blank: true do
-    [_('Home'), _('Business'), _('Mailing'), _('Other')]
+    [_('Home'), _('Business'), _('Mailing'), _('Seasonal'), _('Other')]
   end
 
   def equal_to?(other)


### PR DESCRIPTION
@jbirdjavi @draffensperger or @soberstadt 

1 line change that fixes this:

RuntimeError: Validation failed: Location is not included in the list - #<SiebelDonations::Address:0x007fd31d070b00 @id="1-I9V-1674", @type="Seasonal", @primary=true, @seasonal=true, @address1="1 Beach Dr SE Unit 1602", @city="St Petersburg", @state="FL", @zip="33701-3956", @updated_at="2015-02-27", @delivery_status="Valid">

