### PR TITLE
Change donation fields back to decimal type

### DIFF
--- a/db/migrate/20150302140850_change_donation_fields_back_to_decimal.rb
+++ b/db/migrate/20150302140850_change_donation_fields_back_to_decimal.rb
@@ -1,0 +1,13 @@
+class ChangeDonationFieldsBackToDecimal < ActiveRecord::Migration
+  def change
+    change_column :appeals, :amount, :decimal, precision: 19, scale: 2
+    change_column :contacts, :pledge_amount, :decimal, precision: 19, scale: 2
+    change_column :contacts, :total_donations, :decimal, precision: 19, scale: 2
+    change_column :designation_accounts, :balance, :decimal, precision: 19, scale: 2
+    change_column :designation_profiles, :balance, :decimal, precision: 19, scale: 2
+    change_column :donations, :tendered_amount, :decimal, precision: 19, scale: 2
+    change_column :donations, :amount, :decimal, precision: 19, scale: 2
+    change_column :donations, :appeal_amount, :decimal, precision: 19, scale: 2
+    change_column :donor_accounts, :total_donations, :decimal, precision: 19, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150228143706) do
+ActiveRecord::Schema.define(version: 20150302140850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Turns out the Postgres `money` type requires explicit casts for comparison with integers which caused some exceptions and would be confusing going forward. Also, because we didn't have `schema.rb` specify the `money` type, Travis was doing the tests as if the type as `decimal`/`numeric`. It seems to make the most sense to just use a higher precision `decimal` type. According to the [Postgres docs](http://www.postgresql.org/docs/9.3/static/datatype-numeric.html) the numeric type "is more akin to varchar(n) than to char(n)" so basically having some extra precision doesn't even really hurt us in terms of space.