### PR TITLE
Use notify_or_ignore so ignored errors don't get reported

### DIFF
--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -14,7 +14,7 @@ module Airbrake
     if ::Rails.env.development? || ::Rails.env.test?
       raise e
     else
-      Airbrake.notify(e, opts)
+      Airbrake.notify_or_ignore(e, opts)
     end
   end
 end


### PR DESCRIPTION
Turns out that `Airbrake.notify` always logs an exception even if it's in the ignored list, so just use `notify_or_ignore` in our `raise_or_notify` method instead.