### PR TITLE
Retry Google sync job on unauthorized errors

### DIFF
--- a/app/models/google_contacts_integrator.rb
+++ b/app/models/google_contacts_integrator.rb
@@ -30,6 +30,9 @@ class GoogleContactsIntegrator
 
   def self.retry_on_api_errs
     yield
+  rescue GoogleContactsApi::UnauthorizedError
+    # Try job again which will refresh the token
+    raise LowerRetryWorker::RetryJobButNoAirbrakeError
   rescue OAuth2::Error => e
     if e.response && e.response.status >= 500 || e.response.status == 403 # Server errs or rate limit exceeded
       # For the rate limit error, we need to wait up to an hour, so we should put the job in the retry queue


### PR DESCRIPTION
There is logic to refresh the auth token in `GoogleAccount#contacts_api_user` (which the `GoogleContactsIntegrator` calls for every API call), but still some unauthorized errors are sneaking in. Perhaps it has to do with the token expiring during the code execution or something. At any rate, a reasonable thing to do is to just ignore the error and retry the job.