### PR TITLE
MPDX-282 Delete donations that don't show up in Siebel anymore

### DIFF
--- a/app/models/siebel.rb
+++ b/app/models/siebel.rb
@@ -97,9 +97,9 @@ class Siebel < DataServer
         add_or_update_donation(donation, da, profile)
       end
 
-      #Check for removed donations
+      # Check for removed donations
       all_current_donations_relation = da.donations.where('donation_date > ? AND donation_date < ?', rails_start_date, rails_end_date)
-                                           .where.not(remote_id: nil)
+                                       .where.not(remote_id: nil)
       all_current_donations_array = all_current_donations_relation.to_a
       SiebelDonations::Donation.find(designations: da.designation_number, donation_date_start: start_date,
                                      donation_date_end: end_date).each do |siebel_donation|
@@ -107,7 +107,7 @@ class Siebel < DataServer
         all_current_donations_array.delete(donation)
       end
 
-      #Double check removed donations straight from Siebel
+      # Double check removed donations straight from Siebel
       all_current_donations_array.each do |donation|
         donation_date = donation.donation_date.strftime('%Y-%m-%d')
         siebel_donation = SiebelDonations::Donation.find(designations: da.designation_number, donors: donation.donor_account.account_number,

--- a/app/models/siebel.rb
+++ b/app/models/siebel.rb
@@ -99,6 +99,7 @@ class Siebel < DataServer
 
       #Check for removed donations
       all_current_donations_relation = da.donations.where('donation_date > ? AND donation_date < ?', rails_start_date, rails_end_date)
+                                           .where.not(remote_id: nil)
       all_current_donations_array = all_current_donations_relation.to_a
       SiebelDonations::Donation.find(designations: da.designation_number, donation_date_start: start_date,
                                      donation_date_end: end_date).each do |siebel_donation|

--- a/app/models/siebel.rb
+++ b/app/models/siebel.rb
@@ -79,19 +79,39 @@ class Siebel < DataServer
 
   def import_donations(profile, start_date = nil, end_date = nil)
     # if no date_from was passed in, use min date from query_ini
+    rails_start_date = start_date
     if start_date.blank?
       start_date = @org.minimum_gift_date ? @org.minimum_gift_date : '01/01/2004'
-      start_date = Date.strptime(start_date, '%m/%d/%Y').strftime('%Y-%m-%d')
+      rails_start_date = Date.strptime(start_date, '%m/%d/%Y')
+      start_date = rails_start_date.strftime('%Y-%m-%d')
     else
       start_date = start_date.strftime('%Y-%m-%d')
     end
 
-    end_date = end_date ? Date.strptime(end_date, '%m/%d/%Y').strftime('%Y-%m-%d') : Time.now.strftime('%Y-%m-%d')
+    rails_end_date = end_date ? Date.strptime(end_date, '%m/%d/%Y') : Time.now
+    end_date = rails_end_date.strftime('%Y-%m-%d')
 
     profile.designation_accounts.each do |da|
       SiebelDonations::Donation.find(designations: da.designation_number, posted_date_start: start_date,
                                      posted_date_end: end_date).each do |donation|
         add_or_update_donation(donation, da, profile)
+      end
+
+      #Check for removed donations
+      all_current_donations_relation = da.donations.where('donation_date > ? AND donation_date < ?', rails_start_date, rails_end_date)
+      all_current_donations_array = all_current_donations_relation.to_a
+      SiebelDonations::Donation.find(designations: da.designation_number, donation_date_start: start_date,
+                                     donation_date_end: end_date).each do |siebel_donation|
+        donation = all_current_donations_relation.where(remote_id: siebel_donation.id).first
+        all_current_donations_array.delete(donation)
+      end
+
+      #Double check removed donations straight from Siebel
+      all_current_donations_array.each do |donation|
+        donation_date = donation.donation_date.strftime('%Y-%m-%d')
+        siebel_donation = SiebelDonations::Donation.find(designations: da.designation_number, donors: donation.donor_account.account_number,
+                                                         start_date: donation_date, end_date: donation_date)
+        donation.destroy unless siebel_donation.present?
       end
     end
   end

--- a/spec/models/siebel_spec.rb
+++ b/spec/models/siebel_spec.rb
@@ -96,9 +96,9 @@ describe Siebel do
       donor_account.save
 
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
-        .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+          .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
-        .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+          .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
 
       designation_profile.designation_accounts << da1
       expect {
@@ -106,15 +106,44 @@ describe Siebel do
       }.to change { da1.donations.count }.by(1)
 
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
-        .to_return(status: 200, body: '[]')
+          .to_return(status: 200, body: '[]')
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
-        .to_return(status: 200, body: '[]')
+          .to_return(status: 200, body: '[]')
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donors=#{donor_account.account_number}&end_date=2012-12-18&response_timeout=60000&start_date=2012-12-18")
-        .to_return(status: 200, body: '[]')
+          .to_return(status: 200, body: '[]')
 
       expect {
         siebel.send(:import_donations, designation_profile)
       }.to change { da1.donations.count }.by(-1)
+    end
+
+    it 'does not remove a manually entered donation if it is not in the download list' do
+      donor_account.account_number = 'MyString'
+      donor_account.save
+      donation = create(:donation, donor_account: donor_account, designation_account: da1, donation_date: 2.weeks.ago, remote_id: nil)
+
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
+          .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
+          .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+
+      designation_profile.designation_accounts << da1
+      expect {
+        siebel.send(:import_donations, designation_profile)
+      }.to change { da1.donations.count }.by(1)
+
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
+          .to_return(status: 200, body: '[]')
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
+          .to_return(status: 200, body: '[]')
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donors=#{donor_account.account_number}&end_date=2012-12-18&response_timeout=60000&start_date=2012-12-18")
+          .to_return(status: 200, body: '[]')
+
+      expect {
+        siebel.send(:import_donations, designation_profile)
+      }.to change { da1.donations.count }.by(-1)
+
+      Donation.exists?(donation.id).should be true
     end
   end
 

--- a/spec/models/siebel_spec.rb
+++ b/spec/models/siebel_spec.rb
@@ -82,11 +82,39 @@ describe Siebel do
     it 'imports a new donation from the donor system' do
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
         .to_return(status: 200, body: '[ { "id": "1-IGQAM", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "439362786", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
+        .to_return(status: 200, body: '[ { "id": "1-IGQAM", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "439362786", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
 
       designation_profile.designation_accounts << da1
 
       siebel.should_receive(:add_or_update_donation)
       siebel.import_donations(designation_profile)
+    end
+
+    it 'removes a donation if it is not in the download list' do
+      donor_account.account_number = 'MyString'
+      donor_account.save
+
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
+        .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
+        .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+
+      designation_profile.designation_accounts << da1
+      expect {
+        siebel.send(:import_donations, designation_profile)
+      }.to change { da1.donations.count }.by(1)
+
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
+        .to_return(status: 200, body: '[]')
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
+        .to_return(status: 200, body: '[]')
+      stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donors=#{donor_account.account_number}&end_date=2012-12-18&response_timeout=60000&start_date=2012-12-18")
+        .to_return(status: 200, body: '[]')
+
+      expect {
+        siebel.send(:import_donations, designation_profile)
+      }.to change { da1.donations.count }.by(-1)
     end
   end
 

--- a/spec/models/siebel_spec.rb
+++ b/spec/models/siebel_spec.rb
@@ -96,25 +96,25 @@ describe Siebel do
       donor_account.save
 
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
-          .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+        .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
-          .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+        .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
 
       designation_profile.designation_accounts << da1
-      expect {
+      expect do
         siebel.send(:import_donations, designation_profile)
-      }.to change { da1.donations.count }.by(1)
+      end.to change { da1.donations.count }.by(1)
 
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
-          .to_return(status: 200, body: '[]')
+        .to_return(status: 200, body: '[]')
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
-          .to_return(status: 200, body: '[]')
+        .to_return(status: 200, body: '[]')
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donors=#{donor_account.account_number}&end_date=2012-12-18&response_timeout=60000&start_date=2012-12-18")
-          .to_return(status: 200, body: '[]')
+        .to_return(status: 200, body: '[]')
 
-      expect {
+      expect do
         siebel.send(:import_donations, designation_profile)
-      }.to change { da1.donations.count }.by(-1)
+      end.to change { da1.donations.count }.by(-1)
     end
 
     it 'does not remove a manually entered donation if it is not in the download list' do
@@ -123,25 +123,25 @@ describe Siebel do
       donation = create(:donation, donor_account: donor_account, designation_account: da1, donation_date: 2.weeks.ago, remote_id: nil)
 
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
-          .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+        .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
-          .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
+        .to_return(status: 200, body: '[ { "id": "1-IGQAP", "amount": "100.00", "designation": "' + da1.designation_number + '", "donorId": "' + donor_account.account_number + '", "donationDate": "2012-12-18", "postedDate": "2012-12-21", "paymentMethod": "Check", "channel": "Mail", "campaignCode": "000000" } ]')
 
       designation_profile.designation_accounts << da1
-      expect {
+      expect do
         siebel.send(:import_donations, designation_profile)
-      }.to change { da1.donations.count }.by(1)
+      end.to change { da1.donations.count }.by(1)
 
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&posted_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&posted_date_start=2004-01-01")
-          .to_return(status: 200, body: '[]')
+        .to_return(status: 200, body: '[]')
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donation_date_end=#{Date.today.strftime('%Y-%m-%d')}&response_timeout=60000&donation_date_start=2004-01-01")
-          .to_return(status: 200, body: '[]')
+        .to_return(status: 200, body: '[]')
       stub_request(:get, "https://wsapi.ccci.org/wsapi/rest/donations?designations=#{da1.designation_number}&donors=#{donor_account.account_number}&end_date=2012-12-18&response_timeout=60000&start_date=2012-12-18")
-          .to_return(status: 200, body: '[]')
+        .to_return(status: 200, body: '[]')
 
-      expect {
+      expect do
         siebel.send(:import_donations, designation_profile)
-      }.to change { da1.donations.count }.by(-1)
+      end.to change { da1.donations.count }.by(-1)
 
       Donation.exists?(donation.id).should be true
     end


### PR DESCRIPTION
This is a tricky one, since if I got it wrong, donations will go missing.

Basically (for Siebel only at this point), when downloading donation data, I do an extra pull from Siebel by *donation* date (not posted date) for the date range given, and compare the results to what donations exist in the database for that designation account and date range.  If there are any donations in the database that don't exist in Siebel, I do one extra Siebel check just for that donation just to make sure that it doesn't exist in Siebel anymore, and then delete it.

This is for cases where Donation Services mistakenly credits a donation to a given designation number, realizes it's a mistake, and then pulls it back out again.