### PR TITLE
Sync Google contact accounts one by one

### DIFF
--- a/app/models/account_list.rb
+++ b/app/models/account_list.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/ClassLength
+
 # This class provides the flexibility needed for one person to have
 # multiple designation accounts in multiple countries. In that scenario
 # it didn't make sense to associate a contact with a designation
@@ -393,6 +395,10 @@ class AccountList < ActiveRecord::Base
     emails_with_nils.compact
   end
 
+  def sync_with_google_contacts
+    lower_retry_async(:perform_google_contacts_sync)
+  end
+
   private
 
   def import_data
@@ -485,5 +491,9 @@ class AccountList < ActiveRecord::Base
         )
       end
     end
+  end
+
+  def perform_google_contacts_sync
+    google_integrations.where(contacts_integration: true).each { |g_i| g_i.sync_data('contacts') }
   end
 end

--- a/app/models/account_list.rb
+++ b/app/models/account_list.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Metrics/ClassLength
-
 # This class provides the flexibility needed for one person to have
 # multiple designation accounts in multiple countries. In that scenario
 # it didn't make sense to associate a contact with a designation
@@ -185,7 +183,6 @@ class AccountList < ActiveRecord::Base
       people_with_birthdays = people.where("(people.anniversary_month = ? AND people.anniversary_day >= ?)
                                            OR (people.anniversary_month = ? AND people.anniversary_day <= ?)",
                                            start_month, start_date.day, end_month, end_date.day)
-
     end
     people_with_birthdays.order('people.anniversary_month, people.anniversary_day').merge(contacts.active)
   end
@@ -202,10 +199,9 @@ class AccountList < ActiveRecord::Base
 
   def bottom_50_percent
     unless @bottom_50_percent
-      financial_partners_count = contacts.where('pledge_amount > 0').count
       @bottom_50_percent = contacts.where('pledge_amount > 0')
                            .order('(pledge_amount::numeric / (pledge_frequency::numeric))')
-                           .limit(financial_partners_count / 2)
+                           .limit(contacts.where('pledge_amount > 0').count / 2)
     end
     @bottom_50_percent
   end
@@ -396,7 +392,7 @@ class AccountList < ActiveRecord::Base
   end
 
   def sync_with_google_contacts
-    lower_retry_async(:perform_google_contacts_sync)
+    google_integrations.where(contacts_integration: true).each { |g_i| g_i.sync_data('contacts') }
   end
 
   private
@@ -467,8 +463,7 @@ class AccountList < ActiveRecord::Base
       vars = { EMAIL: u.email.email, FNAME: u.first_name, LNAME: u.last_name,
                GROUPINGS: [{ id: APP_CONFIG['mailchimp_grouping_id'], groups: group }] }
       gb.list_subscribe(id: APP_CONFIG['mailchimp_list'], email_address: vars[:EMAIL], update_existing: true,
-                        double_optin: false, merge_vars: vars, send_welcome: false, replace_interests: false
-      )
+                        double_optin: false, merge_vars: vars, send_welcome: false, replace_interests: false)
     end
   end
 
@@ -487,13 +482,8 @@ class AccountList < ActiveRecord::Base
         groups -= [group]
         vars = { GROUPINGS: [{ id: APP_CONFIG['mailchimp_grouping_id'], groups: groups.join(', ') }] }
         gb.list_update_member(id: APP_CONFIG['mailchimp_list'], email_address: row['email'], merge_vars: vars,
-                              replace_interests: true
-        )
+                              replace_interests: true)
       end
     end
-  end
-
-  def perform_google_contacts_sync
-    google_integrations.where(contacts_integration: true).each { |g_i| g_i.sync_data('contacts') }
   end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -430,7 +430,7 @@ class Contact < ActiveRecord::Base
   end
 
   def sync_with_google_contacts
-    account_list.sync_with_google_contacts
+    account_list.lower_retry_async(:sync_with_google_contacts)
   end
 
   def delete_from_prayer_letters

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -430,7 +430,7 @@ class Contact < ActiveRecord::Base
   end
 
   def sync_with_google_contacts
-    account_list.google_integrations.where(contacts_integration: true).each { |g_i| g_i.queue_sync_data('contacts') }
+    account_list.sync_with_google_contacts
   end
 
   def delete_from_prayer_letters

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -485,4 +485,13 @@ describe Contact do
       expect { contact.merge_people }.to_not raise_error
     end
   end
+
+  context '#sync_with_google_contacts' do
+    it 'calls sync contacts on the google integration' do
+      create(:google_integration, contacts_integration: true, calendar_integration: false,
+                                  account_list: account_list, google_account: create(:google_account))
+      expect_any_instance_of(GoogleIntegration).to receive(:sync_data)
+      Sidekiq::Testing.inline! { contact.send(:sync_with_google_contacts) }
+    end
+  end
 end


### PR DESCRIPTION
Spencer has had some issues with contacts getting repeatedly updated with PrayerLetters.com and we suspect  the Google contacts sync and an update loop to do with his and his wife's contacts. This change makes it so that multiple Google accounts will have their contacts synced one by one to hopefully avoid the update loop between them.