### PR TITLE
Attempted Google sync 400 err fix: send retry batched requests

### DIFF
--- a/app/models/google_contacts_integrator.rb
+++ b/app/models/google_contacts_integrator.rb
@@ -118,6 +118,7 @@ class GoogleContactsIntegrator
     # despite re-applying the sync logic.
     @contacts_to_retry_sync.each(&:reload)
     @contacts_to_retry_sync.each(&method(:sync_contact))
+    api_user.send_batched_requests
 
     delete_g_contact_merge_losers
 

--- a/spec/models/google_contacts_integrator_spec.rb
+++ b/spec/models/google_contacts_integrator_spec.rb
@@ -624,8 +624,9 @@ describe GoogleContactsIntegrator do
         end
       end
 
+      expect(@account.contacts_api_user).to receive(:send_batched_requests).exactly(:twice)
       expect(times_batch_create_or_update_called).to eq(0)
-      @integrator.sync_contacts
+      @integrator.sync_and_return_num_synced
       expect(times_batch_create_or_update_called).to eq(2)
     end
 


### PR DESCRIPTION
We've had a lot of Google contacts sync 400 (bad request) errors recently. Looking at the XML it's sending, it looks like there are contacts that are being sent multiple times in the same batch which triggers the error. I didn't actually reproduce the error, but looking at the code, I think this fix may do it.

When a contact is deleted or modified during a sync Google gives a 404/412 error and then our response is to basically retry the sync for those particular contacts one time, but I had forgotten to flush the batch of those which I think may be causing that duplication.