### PR TITLE
Guard Rubocop autocorrect

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -18,7 +18,7 @@ group :red_green_refactor, halt_on_fail: true do
     watch(%r{^app/views/(.+)/.*\.(erb|haml)$})          { |m| "spec/requests/#{m[1]}_spec.rb" }
   end
 
-  guard :rubocop, all_on_start: false, cli: ['--format', 'clang', '--rails'] do
+  guard :rubocop, all_on_start: false, cli: ['--format', 'clang', '--rails', '--auto-correct'] do
     watch(%r{.+\.rb$})
     watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
   end


### PR DESCRIPTION
With the recent whitespace cops enabled, I think having `guard` autocorrect Rubocop errors will make development easier.