### PR TITLE
Just do one check for Google contacts to sync

### DIFF
--- a/spec/models/google_contacts_integrator_spec.rb
+++ b/spec/models/google_contacts_integrator_spec.rb
@@ -29,7 +29,7 @@ describe GoogleContactsIntegrator do
     it 'syncs contacts and records last synced time' do
       expect(@integrator).to receive(:setup_assigned_remote_ids)
 
-      expect(@integrator).to receive(:contacts_to_sync).and_return([@contact], [])
+      expect(@integrator).to receive(:contacts_to_sync).and_return([@contact])
       expect(@integrator).to receive(:sync_contact).with(@contact)
 
       now = Time.now


### PR DESCRIPTION
My idea with this originally was that we would check for more changed contacts after the sync in case the user changed any more on MPDX or Google during the sync (particularly for the first time sync which takes a while).

However, if multiple Google sync jobs are running at the same time the check for updates will see the contacts that the other job already synced. And because `sidekiq-unique-jobs` doesn't keep jobs unique when they get retried, I believe this is causing Sidekiq jobs to get queued up.

There were a bunch of duplicate Google contacts sync jobs for the same account when I looked recently.