### PR TITLE
Wrap new notification checks in $rollout

### DIFF
--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -12,6 +12,10 @@ class NotificationType < ActiveRecord::Base
   def self.check_all(account_list)
     contacts = {}
     types.each do |type|
+      unless $rollout.active?(:new_notifications, account_list)
+        next if type.in?(['NotificationType::LargerGift', 'NotificationType::LongTimeFrameGift',
+                         'NotificationType::RecontinuingGift', 'NotificationType::SmallerGift'])
+      end
       type_instance = type.constantize.first
       actions = account_list.notification_preferences.find_by_notification_type_id(type_instance.id).try(:actions)
       next unless (Array.wrap(actions) & NotificationPreference.default_actions).present?

--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -14,7 +14,7 @@ class NotificationType < ActiveRecord::Base
     types.each do |type|
       unless $rollout.active?(:new_notifications, account_list)
         next if type.in?(['NotificationType::LargerGift', 'NotificationType::LongTimeFrameGift',
-                         'NotificationType::RecontinuingGift', 'NotificationType::SmallerGift'])
+                          'NotificationType::RecontinuingGift', 'NotificationType::SmallerGift'])
       end
       type_instance = type.constantize.first
       actions = account_list.notification_preferences.find_by_notification_type_id(type_instance.id).try(:actions)

--- a/app/views/preferences/index.html.erb
+++ b/app/views/preferences/index.html.erb
@@ -60,6 +60,9 @@
 
       <% NotificationType.all.each do |notification_type| %>
         <% field_name = notification_type.class.to_s.split('::').last.to_s.underscore.to_sym %>
+        <% unless $rollout.active?(:new_notifications, current_account_list) %>
+            <% next if notification_type.type.in?(['NotificationType::LargerGift', 'NotificationType::LongTimeFrameGift', 'NotificationType::RecontinuingGift', 'NotificationType::SmallerGift']) %>
+        <% end %>
         <div class="field">
           <strong><%= f.label field_name, _(notification_type.description) %></strong>
           <%= check_box_tag "preference_set[#{field_name}][actions][]", 'email', f.object.send(field_name).include?('email') %>

--- a/spec/models/overall_notifications_spec.rb
+++ b/spec/models/overall_notifications_spec.rb
@@ -15,6 +15,7 @@ describe 'Overall notification tests' do
   let(:account_list2) { create(:account_list) }
 
   before do
+    expect($rollout).to receive(:active?).at_least(:once).with(:new_notifications, anything).and_return(true)
     [
       larger_gift, long_time_frame_gift, recontinuing_gift, smaller_gift, special_gift, started_giving, stopped_giving
     ].each do |notification_type|


### PR DESCRIPTION
After seeing the notifications I got for my personal data, though some were correct, there were several incorrect extra gift notifications. I traced it back to duplicated records in `contact_donor_accounts` which caused duplicated rows and thus higher averages in one of the queries. I should have protected this with `$rollout` from the start. This will allow us to do a gradual rollout first to owners, then testers then everyone. I tested this locally both in the preferences and with a run of the notifications code with and without the rollout activated.