### PR TITLE
Handle dup contact donor accounts for notifications

### DIFF
--- a/app/models/contact_donation_methods.rb
+++ b/app/models/contact_donation_methods.rb
@@ -1,6 +1,9 @@
 module ContactDonationMethods
   def designated_donations
-    donations.where(designation_account_id: account_list.designation_accounts.pluck(:id))
+    # Don't use the "donations" association as that may introduce duplicates and incorrect totals
+    # if there are duplicated records in contact_donor_accounts.
+    Donation.where(donor_account_id: donor_accounts.pluck(:id),
+                   designation_account_id: account_list.designation_accounts.pluck(:id))
   end
 
   def last_donation

--- a/spec/models/contact_donation_methods_spec.rb
+++ b/spec/models/contact_donation_methods_spec.rb
@@ -95,6 +95,11 @@ describe ContactDonationMethods do
       contact.update(pledge_frequency: 12)
       expect(contact.recent_monthly_avg).to eq(9.99 * 2 / 12)
     end
+
+    it 'averages correctly even if there are multiple contact donor account records' do
+      create(:contact_donor_account, contact: contact, donor_account: donor_account)
+      expect(contact.recent_monthly_avg).to eq(9.99 / 2)
+    end
   end
 
   context '#months_from_prev_to_last_donation' do


### PR DESCRIPTION
It seems that some contacts have duplicated `contact_donor_accounts` records and that was causing incorrect averages for the larger gift check. Longer term we should figure out how those duplicates got there in the first place (maybe a merge?), but this fixes the notification logic in the mean time.