### PR TITLE
Fix larger gift notification when partner gave larger then back to normal

### DIFF
--- a/app/models/contact_donation_methods.rb
+++ b/app/models/contact_donation_methods.rb
@@ -26,7 +26,7 @@ module ContactDonationMethods
   end
 
   def monthly_avg_with_prev_gift
-    monthly_avg_over_range(prev_donation_range_start, last_donation_month_end)
+    monthly_avg_over_range(prev_donation_month_start, last_donation_month_end)
   end
 
   def months_from_prev_to_last_donation
@@ -53,12 +53,12 @@ module ContactDonationMethods
         end
   end
 
-  def prev_donation_range_start
+  def prev_donation_month_start
     @recent_avg_range_start ||= begin
       start = [first_donation_date, Date.today << 12, prev_month_donation_date].compact.max
       months_in_range_mod_freq = months_in_range(start, last_donation_month_end) % pledge_frequency
       start <<= pledge_frequency - months_in_range_mod_freq if months_in_range_mod_freq > 0
-      start
+      start.beginning_of_month
     end
   end
 

--- a/app/models/contact_donation_methods.rb
+++ b/app/models/contact_donation_methods.rb
@@ -38,10 +38,10 @@ module ContactDonationMethods
 
   def monthly_avg_over_range(start_date, end_date)
     designated_donations
-        .where('donation_date >= ?', start_date)
-        .where('donation_date <= ?', end_date)
-        .sum(:amount) /
-        months_in_range(start_date, end_date)
+      .where('donation_date >= ?', start_date)
+      .where('donation_date <= ?', end_date)
+      .sum(:amount) /
+      months_in_range(start_date, end_date)
   end
 
   def last_donation_month_end

--- a/app/models/contact_donation_methods.rb
+++ b/app/models/contact_donation_methods.rb
@@ -11,20 +11,22 @@ module ContactDonationMethods
   end
 
   def last_monthly_total
-    designated_donations.where('donation_date >= ?', recent_avg_range_end.beginning_of_month).sum(:amount)
+    designated_donations.where('donation_date >= ?', last_donation_month_end.beginning_of_month).sum(:amount)
   end
 
   def prev_month_donation_date
-    designated_donations.where('donation_date <= ?', (recent_avg_range_end << 1).end_of_month)
+    designated_donations.where('donation_date <= ?', (last_donation_month_end << 1).end_of_month)
       .pluck(:donation_date).first
   end
 
-  def recent_monthly_avg
-    designated_donations
-      .where('donation_date >= ?', recent_avg_range_start)
-      .where('donation_date <= ?', recent_avg_range_end)
-      .sum(:amount) /
-      months_in_range(recent_avg_range_start, recent_avg_range_end)
+  def monthly_avg_current
+    prev_months_to_include = [(pledge_frequency || 1) - 1, 0].max
+    start_date = (last_donation_month_end << prev_months_to_include).beginning_of_month
+    monthly_avg_over_range(start_date, last_donation_month_end)
+  end
+
+  def monthly_avg_with_prev_gift
+    monthly_avg_over_range(prev_donation_range_start, last_donation_month_end)
   end
 
   def months_from_prev_to_last_donation
@@ -34,7 +36,15 @@ module ContactDonationMethods
 
   private
 
-  def recent_avg_range_end
+  def monthly_avg_over_range(start_date, end_date)
+    designated_donations
+        .where('donation_date >= ?', start_date)
+        .where('donation_date <= ?', end_date)
+        .sum(:amount) /
+        months_in_range(start_date, end_date)
+  end
+
+  def last_donation_month_end
     @recent_avg_range_end ||=
         if last_donation_date && month_diff(last_donation_date, Date.today) > 0
           Date.today.prev_month.end_of_month
@@ -43,10 +53,10 @@ module ContactDonationMethods
         end
   end
 
-  def recent_avg_range_start
+  def prev_donation_range_start
     @recent_avg_range_start ||= begin
       start = [first_donation_date, Date.today << 12, prev_month_donation_date].compact.max
-      months_in_range_mod_freq = months_in_range(start, recent_avg_range_end) % pledge_frequency
+      months_in_range_mod_freq = months_in_range(start, last_donation_month_end) % pledge_frequency
       start <<= pledge_frequency - months_in_range_mod_freq if months_in_range_mod_freq > 0
       start
     end

--- a/app/models/notification_type/larger_gift.rb
+++ b/app/models/notification_type/larger_gift.rb
@@ -13,7 +13,8 @@ class NotificationType::LargerGift < NotificationType
     if contact.pledge_frequency < 1
       return contact.last_donation.present? && contact.last_donation.amount > contact.pledge_amount
     end
-    contact.recent_monthly_avg > contact.monthly_pledge
+    contact.monthly_avg_with_prev_gift > contact.monthly_pledge &&
+      contact.monthly_avg_current > contact.monthly_pledge
   end
 
   def task_description_template

--- a/app/models/notification_type/smaller_gift.rb
+++ b/app/models/notification_type/smaller_gift.rb
@@ -13,7 +13,7 @@ class NotificationType::SmallerGift < NotificationType
     if contact.pledge_frequency < 1
       return contact.last_donation.present? && contact.last_donation.amount < contact.pledge_amount
     end
-    contact.recent_monthly_avg < contact.monthly_pledge &&
+    contact.monthly_avg_with_prev_gift < contact.monthly_pledge &&
       contact.last_monthly_total > 0 && contact.last_monthly_total != contact.pledge_amount &&
       !NotificationType::RecontinuingGift.had_recontinuing_gift?(contact)
   end

--- a/app/models/notification_type/started_giving.rb
+++ b/app/models/notification_type/started_giving.rb
@@ -12,6 +12,7 @@ class NotificationType::StartedGiving < NotificationType
       # update pledge amount/received
       contact.pledge_amount = donation.amount if contact.pledge_amount.blank?
       contact.pledge_received = true if contact.pledge_amount == donation.amount
+      contact.pledge_frequency ||= 1 # default to monthly pledge if nil
       contact.save
 
       notification = contact.notifications.create!(notification_type_id: id, event_date: Date.today)

--- a/spec/models/contact_donation_methods_spec.rb
+++ b/spec/models/contact_donation_methods_spec.rb
@@ -87,7 +87,10 @@ describe ContactDonationMethods do
   end
 
   context '#current_monthly_avg' do
-
+    it 'looks at the current donation only including the previous gift' do
+      old_donation.update(amount: 3)
+      expect(contact.monthly_avg_current).to eq(9.99)
+    end
   end
 
   context '#recent_monthly_avg' do

--- a/spec/models/contact_donation_methods_spec.rb
+++ b/spec/models/contact_donation_methods_spec.rb
@@ -86,19 +86,23 @@ describe ContactDonationMethods do
     end
   end
 
+  context '#current_monthly_avg' do
+
+  end
+
   context '#recent_monthly_avg' do
     it 'uses time between donations to calculate average' do
-      expect(contact.recent_monthly_avg).to eq(9.99 / 2)
+      expect(contact.monthly_avg_with_prev_gift).to eq(9.99 / 2)
     end
 
     it 'considers pledge frequency in the average' do
       contact.update(pledge_frequency: 12)
-      expect(contact.recent_monthly_avg).to eq(9.99 * 2 / 12)
+      expect(contact.monthly_avg_with_prev_gift).to eq(9.99 * 2 / 12)
     end
 
     it 'averages correctly even if there are multiple contact donor account records' do
       create(:contact_donor_account, contact: contact, donor_account: donor_account)
-      expect(contact.recent_monthly_avg).to eq(9.99 / 2)
+      expect(contact.monthly_avg_with_prev_gift).to eq(9.99 / 2)
     end
   end
 

--- a/spec/models/contact_donation_methods_spec.rb
+++ b/spec/models/contact_donation_methods_spec.rb
@@ -107,6 +107,13 @@ describe ContactDonationMethods do
       create(:contact_donor_account, contact: contact, donor_account: donor_account)
       expect(contact.monthly_avg_with_prev_gift).to eq(9.99 / 2)
     end
+
+    it 'averages including all donations in the previous donation month' do
+      old_donation.update(donation_date: old_donation.donation_date.end_of_month)
+      create(:donation, donor_account: donor_account, designation_account: da,
+                        donation_date: old_donation.donation_date.beginning_of_month)
+      expect(contact.monthly_avg_with_prev_gift).to eq(9.99 * 3 / 4)
+    end
   end
 
   context '#months_from_prev_to_last_donation' do

--- a/spec/models/notification_type/started_giving_spec.rb
+++ b/spec/models/notification_type/started_giving_spec.rb
@@ -44,6 +44,16 @@ describe NotificationType::StartedGiving do
       notifications = started_giving.check(account_list2)
       notifications.length.should == 0
     end
+
+    it 'sets pledge received and defaults to a monthly pledge when first gift given for financial partner ' do
+      contact.update(pledge_amount: nil, pledge_frequency: nil, pledge_received: false)
+      donation
+      started_giving.check(contact.account_list)
+      contact.reload
+      expect(contact.pledge_amount).to eq(9.99)
+      expect(contact.pledge_frequency).to eq(1)
+      expect(contact.pledge_received).to be_true
+    end
   end
 
   describe '.create_task' do


### PR DESCRIPTION
The previous logic would trigger a larger gift notification if a partner gave a larger gift one month and then gave a normal gift the next month (due to the average including the last gift still being above the pledge). The solution to me seems to be to require both the average including the previous gift and the current average to be more than the monthly pledge for a gift to count as extra/larger.

Also part of this PR is setting the pledge frequency to monthly on the first gift from a financial partner if it's blank. That will allow the larger/smaller gift logic to worker on subsequent months and prompt the user to fix an incorrect pledge (or thank the partner) as necessary.