### PR TITLE
Disable deleted item inputs to avoid validation issues

### DIFF
--- a/app/assets/javascripts/mpdx.js.coffee
+++ b/app/assets/javascripts/mpdx.js.coffee
@@ -66,7 +66,9 @@ $ ->
   $(document).on 'click', 'a[data-behavior=remove_field]', ->
     link = this
     $(link).prev("input[type=hidden]").val("1")
-    $(link).closest("[data-behavior*=field-wrapper]").hide()
+    field_wrapper = $(link).closest("[data-behavior*=field-wrapper]")
+    field_wrapper.hide()
+    field_wrapper.find(':input:not([type=hidden])').attr('disabled', true)
     fieldset = $(link).closest('.fieldset')
     false
 


### PR DESCRIPTION
A user wrote it about having problems saving a contact that had invalid email addresses due to a name being in it e.g. "John Doe <john.doe@example.com>". She said that when she would delete the email address and save the form it would do nothing. It turns out that when you click the delete button next to an email address it hides the elements but the browser still tries to validate the hidden elements and then has an issue trying to focus the hidden invalid element to display the error message. The best solution seems to be to disable the hidden elements of items marked to be deleted (this [stack overflow post](http://stackoverflow.com/questions/22148080/an-invalid-form-control-with-name-is-not-focusable) has more on the issue in general).